### PR TITLE
Update PhysiCell importer

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -62,5 +62,5 @@ jobs:
     - name: Lint with flake8
       shell: bash -l {0}
       run: |
-        flake8 simulariumio --count --verbose --show-source --statistics
-        black --check --exclude vendor simulariumio
+        flake8 simulariumio --count --verbose --show-source --statistics --exclude=*/dep
+        black --check --exclude=".*\/dep\/.*|vendor" simulariumio

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -50,5 +50,5 @@ jobs:
     - name: Lint with flake8
       shell: bash -l {0}
       run: |
-        flake8 simulariumio --count --verbose --show-source --statistics
-        black --check --exclude vendor simulariumio
+        flake8 simulariumio --count --verbose --show-source --statistics --exclude=*/dep
+        black --check --exclude=".*\/dep\/.*|vendor" simulariumio

--- a/examples/Tutorial_custom.ipynb
+++ b/examples/Tutorial_custom.ipynb
@@ -54,9 +54,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Simularium custom data Converter consumes spatiotemporal data from any source. It requires a `TrajectoryData` object as parameter ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.data_objects.html#simulariumio.data_objects.trajectory_data.TrajectoryData)).\n",
+    "The Simularium custom data Converter consumes spatiotemporal data from any source. It requires a `TrajectoryData` object as parameter ([see documentation](https://simularium.github.io/simulariumio/simulariumio.data_objects.html#simulariumio.data_objects.trajectory_data.TrajectoryData)).\n",
     "\n",
-    "If you'd like to specify PDB or OBJ files or color for rendering an agent type, add a `DisplayData` object for that agent type, as shown below ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.data_objects.html#module-simulariumio.data_objects.display_data)).\n"
+    "If you'd like to specify PDB or OBJ files or color for rendering an agent type, add a `DisplayData` object for that agent type, as shown below ([see documentation](https://simularium.github.io/simulariumio/simulariumio.data_objects.html#module-simulariumio.data_objects.display_data)).\n"
    ]
   },
   {

--- a/examples/Tutorial_cytosim.ipynb
+++ b/examples/Tutorial_cytosim.ipynb
@@ -56,9 +56,9 @@
     "* for Couples, use the command `./report couple:state > couples.txt`, which will create `couples.txt`\n",
     "    * in some versions of Cytosim, state is not a reporting option. In this case you can use `./report couple:[name of your couple] > couples_[name of your couple].txt` and provide a filepath for each type of couple in your data. If this is necessary, you should also check the position XYZ columns in your `couples.txt` file and override **position_indices** if they aren't at \\[2, 3, 4\\]\n",
     "\n",
-    "The converter requires a `CytosimData` object as parameter ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.cytosim.html#simulariumio.cytosim.cytosim_data.CytosimData)).\n",
+    "The converter requires a `CytosimData` object as parameter ([see documentation](https://simularium.github.io/simulariumio/simulariumio.cytosim.html#simulariumio.cytosim.cytosim_data.CytosimData)).\n",
     "\n",
-    "If you'd like to specify PDB or OBJ files or color for rendering an agent type, add a `DisplayData` object for that agent type, as shown below ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.data_objects.html#module-simulariumio.data_objects.display_data)).\n"
+    "If you'd like to specify PDB or OBJ files or color for rendering an agent type, add a `DisplayData` object for that agent type, as shown below ([see documentation](https://simularium.github.io/simulariumio/simulariumio.data_objects.html#module-simulariumio.data_objects.display_data)).\n"
    ]
   },
   {

--- a/examples/Tutorial_filters.ipynb
+++ b/examples/Tutorial_filters.ipynb
@@ -79,7 +79,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To reduce the number of agents, use `EveryNthAgentFilter` by providing it to `filter_data()`: ([see Filters documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.filters.html))"
+    "To reduce the number of agents, use `EveryNthAgentFilter` by providing it to `filter_data()`: ([see Filters documentation](https://simularium.github.io/simulariumio/simulariumio.filters.html))"
    ]
   },
   {

--- a/examples/Tutorial_mcell.ipynb
+++ b/examples/Tutorial_mcell.ipynb
@@ -46,9 +46,9 @@
    "source": [
     "The Simularium `McellConverter` consumes spatiotemporal data from MCell. \n",
     "\n",
-    "The converter requires a `McellData` object as a parameter ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.mcell.html#simulariumio.mcell.mcell_data.McellData)).\n",
+    "The converter requires a `McellData` object as a parameter ([see documentation](https://simularium.github.io/simulariumio/simulariumio.mcell.html#simulariumio.mcell.mcell_data.McellData)).\n",
     "\n",
-    "If you'd like to specify PDB or OBJ files or color for rendering an agent type, add a `DisplayData` object for that agent type, as shown below ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.data_objects.html#module-simulariumio.data_objects.display_data)).\n"
+    "If you'd like to specify PDB or OBJ files or color for rendering an agent type, add a `DisplayData` object for that agent type, as shown below ([see documentation](https://simularium.github.io/simulariumio/simulariumio.data_objects.html#module-simulariumio.data_objects.display_data)).\n"
    ]
   },
   {

--- a/examples/Tutorial_md.ipynb
+++ b/examples/Tutorial_md.ipynb
@@ -52,9 +52,9 @@
    "source": [
     "The Simularium `MdConverter` consumes spatiotemporal data from molecular dynamics outputs using the MDAnalysis Python package. \n",
     "\n",
-    "The converter requires a `MdData` object as a parameter ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.md.html#simulariumio.md.md_data.MdData)), which requires a MDAnalysis `Universe` object ([see documentation](https://docs.mdanalysis.org/stable/documentation_pages/core/universe.html))\n",
+    "The converter requires a `MdData` object as a parameter ([see documentation](https://simularium.github.io/simulariumio/simulariumio.md.html#simulariumio.md.md_data.MdData)), which requires a MDAnalysis `Universe` object ([see documentation](https://docs.mdanalysis.org/stable/documentation_pages/core/universe.html))\n",
     "\n",
-    "If you'd like to specify PDB or OBJ files or color for rendering an agent type, add a `DisplayData` object for that agent type, as shown below ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.data_objects.html#module-simulariumio.data_objects.display_data)).\n"
+    "If you'd like to specify PDB or OBJ files or color for rendering an agent type, add a `DisplayData` object for that agent type, as shown below ([see documentation](https://simularium.github.io/simulariumio/simulariumio.data_objects.html#module-simulariumio.data_objects.display_data)).\n"
    ]
   },
   {

--- a/examples/Tutorial_medyan.ipynb
+++ b/examples/Tutorial_medyan.ipynb
@@ -48,9 +48,9 @@
    "source": [
     "The Simularium `MedyanConverter` consumes discrete cell data from MEDYAN. \n",
     "\n",
-    "The converter requires a `MedyanData` object as a parameter ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.medyan.html#simulariumio.medyan.medyan_data.MedyanData)).\n",
+    "The converter requires a `MedyanData` object as a parameter ([see documentation](https://simularium.github.io/simulariumio/simulariumio.medyan.html#simulariumio.medyan.medyan_data.MedyanData)).\n",
     "\n",
-    "If you'd like to specify PDB or OBJ files or color for rendering an agent type, add a `DisplayData` object for that agent type, as shown below ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.data_objects.html#module-simulariumio.data_objects.display_data)).\n"
+    "If you'd like to specify PDB or OBJ files or color for rendering an agent type, add a `DisplayData` object for that agent type, as shown below ([see documentation](https://simularium.github.io/simulariumio/simulariumio.data_objects.html#module-simulariumio.data_objects.display_data)).\n"
    ]
   },
   {

--- a/examples/Tutorial_physicell.ipynb
+++ b/examples/Tutorial_physicell.ipynb
@@ -47,9 +47,9 @@
    "source": [
     "The Simularium `PhysicellConverter` consumes discrete cell data from PhysiCell. \n",
     "\n",
-    "The converter requires a `PhysicellData` object as a parameter ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.physicell.html#simulariumio.physicell.physicell_data.PhysicellData)).\n",
+    "The converter requires a `PhysicellData` object as a parameter ([see documentation](https://simularium.github.io/simulariumio/simulariumio.physicell.html#simulariumio.physicell.physicell_data.PhysicellData)).\n",
     "\n",
-    "If you'd like to specify PDB or OBJ files or color for rendering an agent type, add a `DisplayData` object for that agent type, as shown below ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.data_objects.html#module-simulariumio.data_objects.display_data)).\n"
+    "If you'd like to specify PDB or OBJ files or color for rendering an agent type, add a `DisplayData` object for that agent type, as shown below ([see documentation](https://simularium.github.io/simulariumio/simulariumio.data_objects.html#module-simulariumio.data_objects.display_data)).\n"
    ]
   },
   {
@@ -127,8 +127,10 @@
      "text": [
       "Reading PhysiCell Data -------------\n",
       "Reading ../simulariumio/tests/data/physicell/output/output00000000.xml\n",
+      "Reading ../simulariumio/tests/data/physicell/output/initial_mesh0.mat\n",
       "Reading ../simulariumio/tests/data/physicell/output/output00000000_cells_physicell.mat\n",
       "Reading ../simulariumio/tests/data/physicell/output/output00000002.xml\n",
+      "Reading ../simulariumio/tests/data/physicell/output/initial_mesh0.mat\n",
       "Reading ../simulariumio/tests/data/physicell/output/output00000002_cells_physicell.mat\n",
       "Converting Trajectory Data to Binary -------------\n",
       "Writing Binary -------------\n",

--- a/examples/Tutorial_plots.ipynb
+++ b/examples/Tutorial_plots.ipynb
@@ -120,7 +120,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Scatterplots require a `ScatterPlotData` object as a parameter ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.plot_readers.html#simulariumio.plot_readers.scatter_plot_reader.ScatterPlotReader))."
+    "Scatterplots require a `ScatterPlotData` object as a parameter ([see documentation](https://simularium.github.io/simulariumio/simulariumio.plot_readers.html#simulariumio.plot_readers.scatter_plot_reader.ScatterPlotReader))."
    ]
   },
   {
@@ -185,7 +185,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Histograms require a `HistogramPlotData` object as a parameter ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.plot_readers.html#simulariumio.plot_readers.histogram_plot_reader.HistogramPlotReader))."
+    "Histograms require a `HistogramPlotData` object as a parameter ([see documentation](https://simularium.github.io/simulariumio/simulariumio.plot_readers.html#simulariumio.plot_readers.histogram_plot_reader.HistogramPlotReader))."
    ]
   },
   {

--- a/examples/Tutorial_readdy.ipynb
+++ b/examples/Tutorial_readdy.ipynb
@@ -47,9 +47,9 @@
    "source": [
     "The Simularium `ReaddyConverter` consumes spatiotemporal data from ReaDDy. \n",
     "\n",
-    "The converter requires a `ReaddyData` object as a parameter ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.readdy.html#simulariumio.readdy.readdy_data.ReaddyData)).\n",
+    "The converter requires a `ReaddyData` object as a parameter ([see documentation](https://simularium.github.io/simulariumio/simulariumio.readdy.html#simulariumio.readdy.readdy_data.ReaddyData)).\n",
     "\n",
-    "If you'd like to specify PDB or OBJ files or color for rendering an agent type, add a `DisplayData` object for that agent type, as shown below ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.data_objects.html#module-simulariumio.data_objects.display_data)).\n"
+    "If you'd like to specify PDB or OBJ files or color for rendering an agent type, add a `DisplayData` object for that agent type, as shown below ([see documentation](https://simularium.github.io/simulariumio/simulariumio.data_objects.html#module-simulariumio.data_objects.display_data)).\n"
    ]
   },
   {

--- a/examples/Tutorial_smoldyn.ipynb
+++ b/examples/Tutorial_smoldyn.ipynb
@@ -56,9 +56,9 @@
    "source": [
     "The Simularium `SmoldynConverter` consumes spatiotemporal data from Smoldyn. \n",
     "\n",
-    "The converter requires a `SmoldynData` object as a parameter ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.smoldyn.html#simulariumio.smoldyn.smoldyn_data.SmoldynData)).\n",
+    "The converter requires a `SmoldynData` object as a parameter ([see documentation](https://simularium.github.io/simulariumio/simulariumio.smoldyn.html#simulariumio.smoldyn.smoldyn_data.SmoldynData)).\n",
     "\n",
-    "If you'd like to specify PDB or OBJ files or color for rendering an agent type, add a `DisplayData` object for that agent type, as shown below ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.data_objects.html#module-simulariumio.data_objects.display_data)).\n"
+    "If you'd like to specify PDB or OBJ files or color for rendering an agent type, add a `DisplayData` object for that agent type, as shown below ([see documentation](https://simularium.github.io/simulariumio/simulariumio.data_objects.html#module-simulariumio.data_objects.display_data)).\n"
    ]
   },
   {

--- a/examples/Tutorial_springsalad.ipynb
+++ b/examples/Tutorial_springsalad.ipynb
@@ -46,9 +46,9 @@
    "source": [
     "The Simularium `SpringsaladConverter` consumes spatiotemporal data from SpringSaLaD. \n",
     "\n",
-    "The converter requires a `SpringsaladData` object as a parameter ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.springsalad.html#simulariumio.springsalad.springsalad_data.SpringsaladData).\n",
+    "The converter requires a `SpringsaladData` object as a parameter ([see documentation](https://simularium.github.io/simulariumio/simulariumio.springsalad.html#simulariumio.springsalad.springsalad_data.SpringsaladData).\n",
     "\n",
-    "If you'd like to specify PDB or OBJ files or color for rendering an agent type, add a `DisplayData` object for that agent type, as shown below ([see documentation](https://allen-cell-animated.github.io/simulariumio/simulariumio.data_objects.html#module-simulariumio.data_objects.display_data)).\n"
+    "If you'd like to specify PDB or OBJ files or color for rendering an agent type, add a `DisplayData` object for that agent type, as shown below ([see documentation](https://simularium.github.io/simulariumio/simulariumio.data_objects.html#module-simulariumio.data_objects.display_data)).\n"
    ]
   },
   {

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,8 @@ requires = tox-conda
 deps =
     .[test]
 commands =
-    flake8 simulariumio --count --verbose --show-source --statistics
-    black --check simulariumio
+    flake8 simulariumio --count --verbose --show-source --statistics --exclude=*/dep
+    black --check --exclude=".*\/dep\/.*" simulariumio
 
 [testenv]
 setenv =


### PR DESCRIPTION
Problem
=======
PhysiCell has made updates to their import script and we want to pull them in to stay compatible with new PhysiCell output files.

Solution
========
Since PhysiCell has a Python script for import but not a Python package, we have our own copy of their script in `simulariumio/physicell/dep/`. I just copied in their new updates.

We want to merge this ahead of our session at their workshop on Tuesday next week.

## Type of change
- New feature (non-breaking change which adds functionality)

Change summary:
---------------
* update pyMCSD.py
