### PR TITLE
Bugfix/validate agent id size

### DIFF
--- a/simulariumio/constants.py
+++ b/simulariumio/constants.py
@@ -127,3 +127,6 @@ def JMOL_COLORS() -> pd.DataFrame:
     """
     this_dir, _ = os.path.split(__file__)
     return pd.read_csv(os.path.join(this_dir, JMOL_COLORS_CSV_PATH))
+
+
+MAX_AGENT_ID = 0x80000000  # Agent IDs should fit in a 32 bit signed int

--- a/simulariumio/trajectory_converter.py
+++ b/simulariumio/trajectory_converter.py
@@ -154,7 +154,7 @@ class TrajectoryConverter:
         """
         JsonWriter.save_plot_data(self._data.plots, output_path)
 
-    def save(self, output_path: str, binary: bool = True):
+    def save(self, output_path: str, binary: bool = True, validate_ids: bool = True):
         """
         Save the current simularium data in .simularium JSON format
         at the output path
@@ -166,8 +166,11 @@ class TrajectoryConverter:
         binary: bool (optional)
             save in binary format? otherwise use JSON
             Default: True
+        validate_ids: bool
+            additional validation to check agent ID size?
+            Default = True
         """
         if binary:
-            BinaryWriter.save(self._data, output_path)
+            BinaryWriter.save(self._data, output_path, validate_ids)
         else:
-            JsonWriter.save(self._data, output_path)
+            JsonWriter.save(self._data, output_path, validate_ids)

--- a/simulariumio/writers/binary_writer.py
+++ b/simulariumio/writers/binary_writer.py
@@ -376,7 +376,9 @@ class BinaryWriter(Writer):
         return len(databytes) + block_header_length
 
     @staticmethod
-    def save(trajectory_data: TrajectoryData, output_path: str) -> None:
+    def save(
+        trajectory_data: TrajectoryData, output_path: str, validate_ids: bool
+    ) -> None:
         """
         Save the simularium data in .simularium binary format
         at the output path
@@ -386,7 +388,11 @@ class BinaryWriter(Writer):
             the data to save
         output_path: str
             where to save the file
+        validate_ids: bool
+            additional validation to check agent ID size?
         """
+        if validate_ids:
+            Writer._validate_ids(trajectory_data)
         (
             binary_headers,
             trajectory_infos,

--- a/simulariumio/writers/json_writer.py
+++ b/simulariumio/writers/json_writer.py
@@ -158,7 +158,9 @@ class JsonWriter(Writer):
         return simularium_data
 
     @staticmethod
-    def save(trajectory_data: TrajectoryData, output_path: str) -> None:
+    def save(
+        trajectory_data: TrajectoryData, output_path: str, validate_ids: bool
+    ) -> None:
         """
         Save the simularium data in .simularium JSON format
         at the output path
@@ -168,7 +170,11 @@ class JsonWriter(Writer):
             the data to save
         output_path: str
             where to save the file
+        validate_ids: bool (optional)
+            additional validation to check agent ID size?
         """
+        if validate_ids:
+            Writer._validate_ids(trajectory_data)
         json_data = JsonWriter.format_trajectory_data(trajectory_data)
         print("Writing JSON -------------")
         with open(f"{output_path}.simularium", "w+") as outfile:

--- a/simulariumio/writers/writer.py
+++ b/simulariumio/writers/writer.py
@@ -18,7 +18,10 @@ from ..constants import (
     VIZ_TYPE,
     DISPLAY_TYPE,
     CURRENT_VERSION,
+    MAX_AGENT_ID,
 )
+
+from ..exceptions import DataError
 
 ###############################################################################
 
@@ -35,7 +38,7 @@ class Writer(ABC):
 
     @staticmethod
     @abstractmethod
-    def save(self, trajectory_data: TrajectoryData) -> None:
+    def save(self, trajectory_data: TrajectoryData, validate_ids: bool) -> None:
         pass
 
     @staticmethod
@@ -264,6 +267,17 @@ class Writer(ABC):
                 agent_index += V1_SPATIAL_BUFFER_STRUCT.NSP_INDEX - 1
                 get_n_subpoints = True
         return True
+
+    @staticmethod
+    def _validate_ids(trajectory_data: TrajectoryData) -> None:
+        """
+        Check if agent unique IDs are valid 32 bit integers
+        returns a message identifying violating agent ID
+        """
+        agent_unique_ids = trajectory_data.agent_data.unique_ids
+        for uid in np.ndarray.flatten(agent_unique_ids):
+            if uid > MAX_AGENT_ID:
+                raise DataError(f"Agent IDs is larger than a 32 bit integer: {uid} ")
 
     @staticmethod
     def _check_type_matches_subpoints(


### PR DESCRIPTION
Problem
=======
Simulariumio should error if Agent IDs are too large
[#78](https://github.com/simularium/simulariumio/issues/78)

Solution
========
If agent IDs are larger than a 32-bit signed int, throw a data error instead of writing to the .simulariumio file. This check is optional, and users can save with the `validate_ids` argument set to `False` if they want to avoid the additional validation step in order to improve performance.

I also manually verified that all of our converters are generating agent IDs sensibly and not continuing to increment agent IDs unnecessarily in subsequent time steps.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

Change summary:
---------------
* Add check in writer to verify that all agent IDs are small enough to be represented as a 32 bit signed int
* Add test to ensure check is working properly

