### PR TITLE
import recipeloader from main package

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
         os: [ubuntu-latest]
 
     steps:

--- a/environment.yml
+++ b/environment.yml
@@ -4,4 +4,3 @@ channels:
 dependencies:
   - readdy==2.0.9
   - numpy>=1.20
-  - pyembree>=0.1.6

--- a/environment.yml
+++ b/environment.yml
@@ -4,4 +4,4 @@ channels:
 dependencies:
   - readdy==2.0.9
   - numpy>=1.20
-  - pyembree>=0.1.12
+  - pyembree>=0.1.6

--- a/environment.yml
+++ b/environment.yml
@@ -4,3 +4,4 @@ channels:
 dependencies:
   - readdy==2.0.9
   - numpy>=1.20
+  - pyembree>==0.1.12

--- a/environment.yml
+++ b/environment.yml
@@ -4,4 +4,4 @@ channels:
 dependencies:
   - readdy==2.0.9
   - numpy>=1.20
-  - pyembree>==0.1.12
+  - pyembree>=0.1.12

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ md_requirements = [
 ]
 
 cellpack_requirements = [
-    "cellpack>=1.0.0",
+    "cellpack>=1.0.2",
 ]
 
 setup_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ md_requirements = [
 ]
 
 cellpack_requirements = [
-    "cellpack>=1.0.2",
+    "cellpack>=1.0.3",
 ]
 
 setup_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ md_requirements = [
 ]
 
 cellpack_requirements = [
-    "cellpack>=0.2.3",
+    "cellpack>=1.0.0",
 ]
 
 setup_requirements = [

--- a/simulariumio/cellpack/cellpack_converter.py
+++ b/simulariumio/cellpack/cellpack_converter.py
@@ -7,13 +7,13 @@ import numpy as np
 import json
 from scipy.spatial.transform import Rotation as R
 
+from cellpack import RecipeLoader
 from ..constants import DISPLAY_TYPE, VIZ_TYPE
 from ..data_objects.camera_data import CameraData
 from ..trajectory_converter import TrajectoryConverter
 from ..data_objects import TrajectoryData, AgentData, DimensionData
 from ..data_objects import MetaData, DisplayData
 from .cellpack_data import HAND_TYPE, CellpackData
-from cellpack.autopack.iotools_simple import RecipeLoader
 
 ###############################################################################
 


### PR DESCRIPTION
Problem
=======
Simulariumio was importing a class from a directory that moved. 
Additionally, cellpack is now importing a package that is not compatible with python 3.7

Solution
========
To avoid this problem in the future, I changed the import to the package level in cellpack, and am importing the new version here. I also remove python from our tests here since we're building with 3.9

## Type of change
Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


