### PR TITLE
Feature/load open binary data

### DIFF
--- a/simulariumio/data_objects/input_file_data.py
+++ b/simulariumio/data_objects/input_file_data.py
@@ -67,8 +67,7 @@ class InputFileData:
         if self.file_contents:
             # check file contents string to see if they're binary
             header = self.file_contents[0 : len(BINARY_SETTINGS.FILE_IDENTIFIER)]
-            if header.decode("utf-8") == BINARY_SETTINGS.FILE_IDENTIFIER:
-                return True
+            return header.decode("utf-8") == BINARY_SETTINGS.FILE_IDENTIFIER
         with open(self.file_path, "rb") as open_file:
             # need to be able to do this check with a binary blob rather than just file
             header = open_file.read(len(BINARY_SETTINGS.FILE_IDENTIFIER)).decode(

--- a/simulariumio/data_objects/input_file_data.py
+++ b/simulariumio/data_objects/input_file_data.py
@@ -55,10 +55,11 @@ class InputFileData:
         with open(self.file_path, "r") as myfile:
             return myfile.read()
 
-    def _is_binary_file(self):
+    def _is_binary(self):
         """
-        Is this file binary? (or JSON?)
+        Is this data in binary? (or JSON?)
         """
+        contents = self.get_contents()
         with open(self.file_path, "rb") as open_file:
             header = open_file.read(len(BINARY_SETTINGS.FILE_IDENTIFIER)).decode(
                 "utf-8"

--- a/simulariumio/data_objects/input_file_data.py
+++ b/simulariumio/data_objects/input_file_data.py
@@ -53,14 +53,15 @@ class InputFileData:
         if self.file_contents:
             return self.file_contents
         with open(self.file_path, "r") as myfile:
-            return myfile.read()
+            return myfile.read()  # only works for JSON files right now, maybe use SimulariumBinaryReader._binary_data_from_file()?
+        
 
     def _is_binary(self):
         """
         Is this data in binary? (or JSON?)
         """
-        contents = self.get_contents()
         with open(self.file_path, "rb") as open_file:
+            # need to be able to do this check with a binary blob rather than just file
             header = open_file.read(len(BINARY_SETTINGS.FILE_IDENTIFIER)).decode(
                 "utf-8"
             )

--- a/simulariumio/data_objects/input_file_data.py
+++ b/simulariumio/data_objects/input_file_data.py
@@ -20,7 +20,7 @@ class InputFileData:
     def __init__(
         self,
         file_path: str = "",
-        file_contents: str = "",
+        file_contents: str = "", # we also want bytes, so maybe? | bytes = b'',
     ):
         """
         This object contains data about a file
@@ -30,7 +30,7 @@ class InputFileData:
         file_path: str (optional)
             A string path to the file
             Default: use file_contents instead
-        file_contents: str (optional)
+        file_contents: str (optional) or bytes (optional)
             A string of data from an opened file
             Default: use file_path instead
         """
@@ -54,12 +54,16 @@ class InputFileData:
             return self.file_contents
         with open(self.file_path, "r") as myfile:
             return myfile.read()  # only works for JSON files right now, maybe use SimulariumBinaryReader._binary_data_from_file()?
-        
 
     def _is_binary(self):
         """
         Is this data in binary? (or JSON?)
         """
+        if self.file_contents:
+            # check file contents string to see if they're binary
+            header = self.file_contents[0:len(BINARY_SETTINGS.FILE_IDENTIFIER)]
+            if header.decode("utf-8") == BINARY_SETTINGS.FILE_IDENTIFIER:
+                return True
         with open(self.file_path, "rb") as open_file:
             # need to be able to do this check with a binary blob rather than just file
             header = open_file.read(len(BINARY_SETTINGS.FILE_IDENTIFIER)).decode(

--- a/simulariumio/data_objects/input_file_data.py
+++ b/simulariumio/data_objects/input_file_data.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
+from typing import Union
 
 from ..exceptions import DataError
 from ..constants import BINARY_SETTINGS
@@ -20,7 +21,7 @@ class InputFileData:
     def __init__(
         self,
         file_path: str = "",
-        file_contents: str = "", # we also want bytes, so maybe? | bytes = b'',
+        file_contents: Union[str, bytes] = "",
     ):
         """
         This object contains data about a file
@@ -30,7 +31,7 @@ class InputFileData:
         file_path: str (optional)
             A string path to the file
             Default: use file_contents instead
-        file_contents: str (optional) or bytes (optional)
+        file_contents: str or bytes (optional)
             A string of data from an opened file
             Default: use file_path instead
         """
@@ -48,12 +49,16 @@ class InputFileData:
 
         If file_contents is not empty, return that.
         Otherwise try to open the file at file_path
-        and return the data inside as a string.
+        and return the data inside as a string or as
+        bytes, for binary files.
         """
         if self.file_contents:
             return self.file_contents
+        if self._is_binary():
+            with open(self.file_path, "rb") as myfile:
+                return myfile.read()
         with open(self.file_path, "r") as myfile:
-            return myfile.read()  # only works for JSON files right now, maybe use SimulariumBinaryReader._binary_data_from_file()?
+            return myfile.read()
 
     def _is_binary(self):
         """
@@ -61,7 +66,7 @@ class InputFileData:
         """
         if self.file_contents:
             # check file contents string to see if they're binary
-            header = self.file_contents[0:len(BINARY_SETTINGS.FILE_IDENTIFIER)]
+            header = self.file_contents[0 : len(BINARY_SETTINGS.FILE_IDENTIFIER)]
             if header.decode("utf-8") == BINARY_SETTINGS.FILE_IDENTIFIER:
                 return True
         with open(self.file_path, "rb") as open_file:

--- a/simulariumio/data_objects/input_file_data.py
+++ b/simulariumio/data_objects/input_file_data.py
@@ -69,7 +69,6 @@ class InputFileData:
             header = self.file_contents[0 : len(BINARY_SETTINGS.FILE_IDENTIFIER)]
             return header.decode("utf-8") == BINARY_SETTINGS.FILE_IDENTIFIER
         with open(self.file_path, "rb") as open_file:
-            # need to be able to do this check with a binary blob rather than just file
             header = open_file.read(len(BINARY_SETTINGS.FILE_IDENTIFIER)).decode(
                 "utf-8"
             )

--- a/simulariumio/file_converter.py
+++ b/simulariumio/file_converter.py
@@ -31,7 +31,7 @@ class FileConverter(TrajectoryConverter):
         """
         if display_data is None:
             display_data = {}
-        if input_file._is_binary_file():
+        if input_file._is_binary():
             print("Reading Simularium binary -------------")
             buffer_data = SimulariumBinaryReader.load_binary(input_file)
         else:

--- a/simulariumio/readers/simularium_binary_reader.py
+++ b/simulariumio/readers/simularium_binary_reader.py
@@ -21,14 +21,22 @@ log = logging.getLogger(__name__)
 
 class SimulariumBinaryReader:
     @staticmethod
-    def _binary_data_from_file(input_file: InputFileData) -> BinaryFileData:
+    def _binary_data_from_source(input_file: InputFileData) -> BinaryFileData:
         """
-        Read a .simularium binary file and return multiple views of the data
+        Read a .simularium binary file or take binary input bytes and return
+        multiple views of the data
         """
-        # if input_file.get_contents() returns BinaryFileData, just return that?
         result = BinaryFileData()
+        if input_file.file_contents:
+            result.byte_view = input_file.file_contents
+            result.int_view = np.frombuffer(
+                input_file.file_contents, dtype=np.dtype("I").newbyteorder("<")
+            )
+            result.float_view = np.frombuffer(
+                input_file.file_contents, dtype=np.dtype("f").newbyteorder("<")
+            )
+            return result
         with open(input_file.file_path, "rb") as open_binary_file:
-            # do this for binary in memory too, so no file open
             result.byte_view = open_binary_file.read()
             result.int_view = np.frombuffer(
                 result.byte_view, dtype=np.dtype("I").newbyteorder("<")
@@ -175,7 +183,7 @@ class SimulariumBinaryReader:
         Load data from the input file in .simularium binary format and update it.
         """
         result = {}
-        binary_data = SimulariumBinaryReader._binary_data_from_file(input_file)
+        binary_data = SimulariumBinaryReader._binary_data_from_source(input_file)
         block_info = SimulariumBinaryReader._parse_binary_header(binary_data.byte_view)
         # parse blocks
         found_blocks = []

--- a/simulariumio/readers/simularium_binary_reader.py
+++ b/simulariumio/readers/simularium_binary_reader.py
@@ -25,8 +25,10 @@ class SimulariumBinaryReader:
         """
         Read a .simularium binary file and return multiple views of the data
         """
+        # if input_file.get_contents() returns BinaryFileData, just return that?
         result = BinaryFileData()
         with open(input_file.file_path, "rb") as open_binary_file:
+            # do this for binary in memory too, so no file open
             result.byte_view = open_binary_file.read()
             result.int_view = np.frombuffer(
                 result.byte_view, dtype=np.dtype("I").newbyteorder("<")

--- a/simulariumio/readers/simularium_binary_reader.py
+++ b/simulariumio/readers/simularium_binary_reader.py
@@ -27,23 +27,13 @@ class SimulariumBinaryReader:
         multiple views of the data
         """
         result = BinaryFileData()
-        if input_file.file_contents:
-            result.byte_view = input_file.file_contents
-            result.int_view = np.frombuffer(
-                input_file.file_contents, dtype=np.dtype("I").newbyteorder("<")
-            )
-            result.float_view = np.frombuffer(
-                input_file.file_contents, dtype=np.dtype("f").newbyteorder("<")
-            )
-            return result
-        with open(input_file.file_path, "rb") as open_binary_file:
-            result.byte_view = open_binary_file.read()
-            result.int_view = np.frombuffer(
-                result.byte_view, dtype=np.dtype("I").newbyteorder("<")
-            )
-            result.float_view = np.frombuffer(
-                result.byte_view, dtype=np.dtype("f").newbyteorder("<")
-            )
+        result.byte_view = input_file.get_contents()
+        result.int_view = np.frombuffer(
+            result.byte_view, dtype=np.dtype("I").newbyteorder("<")
+        )
+        result.float_view = np.frombuffer(
+            result.byte_view, dtype=np.dtype("f").newbyteorder("<")
+        )
         return result
 
     @staticmethod

--- a/simulariumio/tests/readers/test_binary_reader.py
+++ b/simulariumio/tests/readers/test_binary_reader.py
@@ -21,7 +21,7 @@ from simulariumio.tests.conftest import binary_test_data, assert_buffers_equal
         ),
     ],
 )
-def test_binary_parsing(
+def test_binary_file_parsing(
     input_path,
     expected_data,
 ):
@@ -30,3 +30,26 @@ def test_binary_parsing(
     expected_converter = TrajectoryConverter(expected_data)
     expected_buffer_data = JsonWriter.format_trajectory_data(expected_converter._data)
     assert_buffers_equal(test_buffer_data, expected_buffer_data)
+
+@pytest.mark.parametrize(
+    "input_path, expected_data",
+    [
+        (
+            "simulariumio/tests/data/binary/binary_test.binary",
+            binary_test_data,
+        ),
+    ],
+)
+def test_binary_parsing(
+    input_path,
+    expected_data,
+):
+    with open(input_path, "rb") as open_binary_file:
+        binary_content = open_binary_file.read()
+        test_converter = FileConverter(
+            input_file=InputFileData(file_contents=binary_content)
+        )
+        test_buffer_data = JsonWriter.format_trajectory_data(test_converter._data)
+        expected_converter = TrajectoryConverter(expected_data)
+        expected_buffer_data = JsonWriter.format_trajectory_data(expected_converter._data)
+        assert_buffers_equal(test_buffer_data, expected_buffer_data)

--- a/simulariumio/tests/readers/test_binary_reader.py
+++ b/simulariumio/tests/readers/test_binary_reader.py
@@ -31,6 +31,7 @@ def test_binary_file_parsing(
     expected_buffer_data = JsonWriter.format_trajectory_data(expected_converter._data)
     assert_buffers_equal(test_buffer_data, expected_buffer_data)
 
+
 @pytest.mark.parametrize(
     "input_path, expected_data",
     [
@@ -51,5 +52,7 @@ def test_binary_parsing(
         )
         test_buffer_data = JsonWriter.format_trajectory_data(test_converter._data)
         expected_converter = TrajectoryConverter(expected_data)
-        expected_buffer_data = JsonWriter.format_trajectory_data(expected_converter._data)
+        expected_buffer_data = JsonWriter.format_trajectory_data(
+            expected_converter._data
+        )
         assert_buffers_equal(test_buffer_data, expected_buffer_data)

--- a/simulariumio/tests/test_input_file_data.py
+++ b/simulariumio/tests/test_input_file_data.py
@@ -27,4 +27,4 @@ from simulariumio import InputFileData
 )
 def test_input_file_is_binary(input_path, is_binary):
     input_file = InputFileData(file_path=input_path)
-    assert input_file._is_binary_file() == is_binary
+    assert input_file._is_binary() == is_binary

--- a/simulariumio/tests/test_input_file_data.py
+++ b/simulariumio/tests/test_input_file_data.py
@@ -28,3 +28,29 @@ from simulariumio import InputFileData
 def test_input_file_is_binary(input_path, is_binary):
     input_file = InputFileData(file_path=input_path)
     assert input_file._is_binary() == is_binary
+
+
+@pytest.mark.parametrize(
+    "file_to_read, is_binary",
+    [
+        (
+            (
+                "simulariumio/tests/data/cytosim/aster_pull3D_couples_actin"
+                "_solid_3_frames/aster_pull3D_couples_actin_solid_3_frames.json"
+            ),
+            False,
+        ),
+        (
+            (
+                "simulariumio/tests/data/binary/"
+                "50filaments_motor_linker_binary.binary"
+            ),
+            True,
+        ),
+    ],
+)
+def test_input_data_binary(file_to_read, is_binary):
+    with open(file_to_read, "rb") as open_binary_file:
+        content = open_binary_file.read()
+        file_data = InputFileData(file_contents=content)
+        assert file_data._is_binary() == is_binary


### PR DESCRIPTION
Problem
=======
For JSON data, can currently use a `InputFileData` with either file_contents or file_path, but for binary data, currently it only works for a binary file_path not file_contents.

[#122](https://github.com/simularium/simulariumio/issues/122)

Solution
========
Added the ability to use `InputFileData` with file_contents for binary data. 
with @blairlyons 

## Type of change
Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires updated or new tests

Change summary:
---------------
* Updated the `_is_binary()` check in `InputFileData` to work for file_contents in addition to file_path
* Updated `SimulariumBinaryReader` to be able to read binary data from file_contents when relevant, instead of just file_path
* Updated some tests to check this new functionality
