### PR TITLE
fix/pin-flake8-pyprojecttoml-to-fix-lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,4 +13,4 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-typing-imports>=1.9.0
-          - flake8-pyprojecttoml
+          - flake8-pyprojecttoml==0.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ lint = [
   "check-manifest>=0.48",
   "flake8>=3.8.3",
   "flake8-debugger>=3.2.1",
-  # "flake8-pyprojecttoml",  # ignored until this package is only Py38
+  # "flake8-pyprojecttoml==0.0.1",  # ignored until this package is only Py38
   "flake8-typing-imports>=1.9.0",
   "isort>=5.7.0",
   "mypy>=0.790",


### PR DESCRIPTION
Lint is broken because flake8-pyprojecttoml released a new version (but its breaking?? not really sure).

Context: because projects are slowly moving over to pyproject.toml files to maintain all their metadata, deps, and tooling stuff, we want to store everything we can in that one file. `flake8` the linter doesn't yet support the pyproject.toml file for reading its configurations. the `flake8-pyprojecttoml` library is a sort of experimental plugin that enables that reading.

I will look for better / more stable ways to handle this in the future.