### PR TITLE
Make agent names case insensitive

### DIFF
--- a/simulariumio/cellpack/cellpack_converter.py
+++ b/simulariumio/cellpack/cellpack_converter.py
@@ -274,7 +274,10 @@ class CellpackConverter(TrajectoryConverter):
             ingredient_data = ingredient["recipe_data"]
             ingredient_key = ingredient_data["name"]
             ingredient_results_data = ingredient["results"]
-            if ingredient_key not in display_data:
+            agent_display_data = TrajectoryConverter._get_display_data_for_agent(
+                ingredient_key, display_data
+            )
+            if agent_display_data is None:
                 agent_display_data = CellpackConverter._get_ingredient_display_data(
                     geo_type, ingredient_data, geometry_url
                 )
@@ -285,8 +288,8 @@ class CellpackConverter(TrajectoryConverter):
                     color=agent_display_data["color"],
                 )
             else:
-                new_name = display_data[ingredient_key].name
-                display_data[new_name] = display_data[ingredient_key]
+                new_name = agent_display_data.name
+                display_data[new_name] = agent_display_data
                 ingredient_key = new_name
             if "coordsystem" in ingredient_data:
                 handedness = (

--- a/simulariumio/mcell/mcell_converter.py
+++ b/simulariumio/mcell/mcell_converter.py
@@ -258,14 +258,18 @@ class McellConverter(TrajectoryConverter):
                     result.positions[
                         time_index, total_mols : total_mols + n_mols, :
                     ] = positions
+                    agent_display_data = (
+                        TrajectoryConverter._get_display_data_for_agent(
+                            raw_type_name, input_data.display_data
+                        )
+                    )
                     result.radii[time_index, total_mols : total_mols + n_mols] = (
                         input_data.meta_data.scale_factor
                         * BLENDER_GEOMETRY_SCALE_FACTOR
                         * (
-                            input_data.display_data[raw_type_name].radius
-                            if raw_type_name in input_data.display_data
-                            and input_data.display_data[raw_type_name].radius
-                            is not None
+                            agent_display_data.radius
+                            if agent_display_data
+                            and agent_display_data.radius is not None
                             else molecule_info[raw_type_name]["display"]["scale"]
                         )
                         * np.ones(n_mols)

--- a/simulariumio/md/md_converter.py
+++ b/simulariumio/md/md_converter.py
@@ -62,11 +62,12 @@ class MdConverter(TrajectoryConverter):
         """
         Get the type_name to use for the particle with the given raw type_name
         """
-        if raw_type_name in input_data.display_data:
-            return input_data.display_data[raw_type_name].name
         element_type = guess_atom_element(raw_type_name)
-        if element_type in input_data.display_data:
-            return input_data.display_data[element_type].name + "#" + raw_type_name
+        for name in input_data.display_data:
+            if raw_type_name.lower() == name.lower():
+                return input_data.display_data[name].name
+            if element_type.lower() == name.lower():
+                return input_data.display_data[name].name + "#" + raw_type_name
         return element_type + "#" + raw_type_name
 
     @staticmethod
@@ -74,17 +75,17 @@ class MdConverter(TrajectoryConverter):
         """
         Get the radius to use for the particle with the given raw_type_name
         """
-        if (
-            raw_type_name in input_data.display_data
-            and input_data.display_data[raw_type_name].radius is not None
-        ):
-            return input_data.display_data[raw_type_name].radius
+        raw_display_data = TrajectoryConverter._get_display_data_for_agent(
+            raw_type_name, input_data.display_data
+        )
+        if raw_display_data and raw_display_data.radius is not None:
+            return raw_display_data.radius
         element_type = guess_atom_element(raw_type_name)
-        if (
-            element_type in input_data.display_data
-            and input_data.display_data[element_type].radius is not None
-        ):
-            return input_data.display_data[element_type].radius
+        element_display_data = TrajectoryConverter._get_display_data_for_agent(
+            element_type, input_data.display_data
+        )
+        if element_display_data and element_display_data.radius is not None:
+            return element_display_data.radius
         if element_type in vdwradii:
             return vdwradii[element_type]
         return 1.0
@@ -107,12 +108,18 @@ class MdConverter(TrajectoryConverter):
         element_type = guess_atom_element(raw_type_name)
         color = MdConverter._get_element_hex_color(element_type, jmol_colors)
         display_data = None
-        if raw_type_name in input_data.display_data:
-            display_data = copy.copy(input_data.display_data[raw_type_name])
+        raw_name_display_data = TrajectoryConverter._get_display_data_for_agent(
+            raw_type_name, input_data.display_data
+        )
+        if raw_name_display_data:
+            display_data = copy.copy(raw_name_display_data)
         else:
             type_name = MdConverter._get_type_name(raw_type_name, input_data)
-            if element_type in input_data.display_data:
-                display_data = copy.copy(input_data.display_data[element_type])
+            element_display_data = TrajectoryConverter._get_display_data_for_agent(
+                type_name, input_data.display_data
+            )
+            if element_display_data:
+                display_data = copy.copy(element_display_data)
                 display_data.name = type_name
             else:
                 display_data = DisplayData(

--- a/simulariumio/readdy/readdy_converter.py
+++ b/simulariumio/readdy/readdy_converter.py
@@ -78,9 +78,11 @@ class ReaddyConverter(TrajectoryConverter):
                 if traj.species_name(tid) in input_data.ignore_types:
                     continue
                 raw_type_name = traj.species_name(tid)
+                input_display_data = TrajectoryConverter._get_display_data_for_agent(
+                    raw_type_name, input_data.display_data
+                )
                 display_data = (
-                    input_data.display_data[raw_type_name]
-                    if raw_type_name in input_data.display_data
+                    input_display_data if input_display_data is not None
                     else DisplayData(
                         name=raw_type_name, display_type=DISPLAY_TYPE.SPHERE
                     )

--- a/simulariumio/smoldyn/smoldyn_converter.py
+++ b/simulariumio/smoldyn/smoldyn_converter.py
@@ -101,12 +101,17 @@ class SmoldynConverter(TrajectoryConverter):
                         float(cols[3]) if is_3D else 0.0,
                     ]
                 )
+
+                # Get the user provided display data for this raw_type_name
+                input_display_data = TrajectoryConverter._get_display_data_for_agent(
+                    raw_type_name, input_data.display_data
+                )
+
                 result.radii[time_index][
                     agent_index
                 ] = input_data.meta_data.scale_factor * (
-                    input_data.display_data[raw_type_name].radius
-                    if raw_type_name in input_data.display_data
-                    and input_data.display_data[raw_type_name].radius is not None
+                    input_display_data.radius
+                    if input_display_data and input_display_data.radius is not None
                     else 1.0
                 )
                 agent_index += 1
@@ -127,6 +132,7 @@ class SmoldynConverter(TrajectoryConverter):
         # get display data (geometry and color)
         for tid in input_data.display_data:
             display_data = input_data.display_data[tid]
+            print(f'display_data.name: {display_data.name}, tid: {tid} ')
             agent_data.display_data[display_data.name] = display_data
         # create TrajectoryData
         input_data.spatial_units.multiply(1.0 / input_data.meta_data.scale_factor)

--- a/simulariumio/smoldyn/smoldyn_converter.py
+++ b/simulariumio/smoldyn/smoldyn_converter.py
@@ -132,7 +132,6 @@ class SmoldynConverter(TrajectoryConverter):
         # get display data (geometry and color)
         for tid in input_data.display_data:
             display_data = input_data.display_data[tid]
-            print(f'display_data.name: {display_data.name}, tid: {tid} ')
             agent_data.display_data[display_data.name] = display_data
         # create TrajectoryData
         input_data.spatial_units.multiply(1.0 / input_data.meta_data.scale_factor)

--- a/simulariumio/springsalad/springsalad_converter.py
+++ b/simulariumio/springsalad/springsalad_converter.py
@@ -119,12 +119,14 @@ class SpringsaladConverter(TrajectoryConverter):
                 )
                 scene_agent_positions[int(cols[1])] = position
                 result.positions[time_index][agent_index] = position
+                input_display_data = TrajectoryConverter._get_display_data_for_agent(
+                    raw_type_name, input_data.display_data
+                )
                 result.radii[time_index][
                     agent_index
                 ] = input_data.meta_data.scale_factor * (
-                    input_data.display_data[raw_type_name].radius
-                    if raw_type_name in input_data.display_data
-                    and input_data.display_data[raw_type_name].radius is not None
+                    input_display_data.radius
+                    if input_display_data and input_display_data.radius is not None
                     else float(cols[2])
                 )
                 agent_index += 1

--- a/simulariumio/tests/converters/test_trajectory_converter.py
+++ b/simulariumio/tests/converters/test_trajectory_converter.py
@@ -1400,6 +1400,7 @@ def test_invalid_agent_id(trajectory, expected_data):
     JsonWriter._validate_ids(converter._data)
     assert expected_data == buffer_data
 
+
 data0 = DisplayData(name="Name 0", display_type=DISPLAY_TYPE.SPHERE)
 data1 = DisplayData(name="Name 1", display_type=DISPLAY_TYPE.FIBER)
 data2 = DisplayData(name="Name 2", display_type=DISPLAY_TYPE.OBJ)
@@ -1407,6 +1408,8 @@ key0 = "Red"
 key1 = "Green"
 key2 = "Blue"
 display_dict = {key0: data0, key1: data1, key2: data2}
+
+
 @pytest.mark.parametrize(
     "key, expected_data",
     [
@@ -1429,4 +1432,6 @@ display_dict = {key0: data0, key1: data1, key2: data2}
     ],
 )
 def test_get_display_data_for_agent(key, expected_data):
-    assert expected_data == TrajectoryConverter._get_display_data_for_agent(key, display_dict)
+    assert expected_data == TrajectoryConverter._get_display_data_for_agent(
+        key, display_dict
+    )

--- a/simulariumio/tests/converters/test_trajectory_converter.py
+++ b/simulariumio/tests/converters/test_trajectory_converter.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from simulariumio import TrajectoryConverter, JsonWriter
+from simulariumio import TrajectoryConverter, JsonWriter, DisplayData
 from simulariumio.tests.conftest import (
     fiber_agents_type_mapping,
     minimal_custom_data,
@@ -19,6 +19,7 @@ from simulariumio.constants import (
     CURRENT_VERSION,
     VIZ_TYPE,
     MAX_AGENT_ID,
+    DISPLAY_TYPE,
 )
 
 from simulariumio.exceptions import DataError
@@ -1398,3 +1399,34 @@ def test_invalid_agent_id(trajectory, expected_data):
     buffer_data = JsonWriter.format_trajectory_data(converter._data)
     JsonWriter._validate_ids(converter._data)
     assert expected_data == buffer_data
+
+data0 = DisplayData(name="Name 0", display_type=DISPLAY_TYPE.SPHERE)
+data1 = DisplayData(name="Name 1", display_type=DISPLAY_TYPE.FIBER)
+data2 = DisplayData(name="Name 2", display_type=DISPLAY_TYPE.OBJ)
+key0 = "Red"
+key1 = "Green"
+key2 = "Blue"
+display_dict = {key0: data0, key1: data1, key2: data2}
+@pytest.mark.parametrize(
+    "key, expected_data",
+    [
+        (
+            key2.upper(),
+            data2,
+        ),
+        (
+            key0.lower(),
+            data0,
+        ),
+        (
+            key1,
+            data1,
+        ),
+        (
+            key0 + "x",
+            None,
+        ),
+    ],
+)
+def test_get_display_data_for_agent(key, expected_data):
+    assert expected_data == TrajectoryConverter._get_display_data_for_agent(key, display_dict)

--- a/simulariumio/trajectory_converter.py
+++ b/simulariumio/trajectory_converter.py
@@ -65,15 +65,33 @@ class TrajectoryConverter:
         If there is no DisplayData for this type, add it
         using the raw type_name and SPHERE display_type
         """
-        if raw_type_name in display_data:
-            display_type_name = display_data[raw_type_name].name
-        else:
-            display_type_name = raw_type_name
-            display_data[display_type_name] = DisplayData(
-                name=display_type_name,
-                display_type=DISPLAY_TYPE.SPHERE,
-            )
+        agent_display_data = TrajectoryConverter._get_display_data_for_agent(
+            raw_type_name, display_data
+        )
+        if agent_display_data:
+            return agent_display_data.name
+
+        display_type_name = raw_type_name
+        display_data[display_type_name] = DisplayData(
+            name=display_type_name,
+            display_type=DISPLAY_TYPE.SPHERE,
+        )
         return display_type_name
+
+    @staticmethod
+    def _get_display_data_for_agent(
+        raw_type_name: str,
+        display_data: Dict[str, DisplayData]
+    ) -> DisplayData | None:
+        """
+        If the provided raw_type_name matches a key in the display data dict,
+        ignoring case, return the corresponding DisplayDat for that key.
+        Otherwise, return None
+        """
+        for input_name in display_data:
+            if input_name.lower() == raw_type_name.lower():
+                return display_data[input_name]
+        return None
 
     @staticmethod
     def _determine_plot_reader(plot_type: str = "scatter") -> [PlotReader]:

--- a/simulariumio/trajectory_converter.py
+++ b/simulariumio/trajectory_converter.py
@@ -82,7 +82,7 @@ class TrajectoryConverter:
     def _get_display_data_for_agent(
         raw_type_name: str,
         display_data: Dict[str, DisplayData]
-    ) -> DisplayData | None:
+    ) -> DisplayData:
         """
         If the provided raw_type_name matches a key in the display data dict,
         ignoring case, return the corresponding DisplayDat for that key.

--- a/simulariumio/trajectory_converter.py
+++ b/simulariumio/trajectory_converter.py
@@ -85,7 +85,7 @@ class TrajectoryConverter:
     ) -> DisplayData:
         """
         If the provided raw_type_name matches a key in the display data dict,
-        ignoring case, return the corresponding DisplayDat for that key.
+        ignoring case, return the corresponding DisplayData for that key.
         Otherwise, return None
         """
         for input_name in display_data:


### PR DESCRIPTION
Problem
=======
Currently, if you want to provide display data, you have to match the agent name in the data file exactly, including having the proper casing. This is kinda annoying, especially as we move to autoconversion.
[Link to ticket](https://github.com/simularium/simulariumio/issues/123)

Solution
========
Made casing for matching agent names for display data case insensitive 

## Type of change
Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires updated or new tests

Change summary:
---------------
* For relevant trajectory converters, made changed the keys in the display data dict, which represent agent names, lowercase
* When comparing those to the agent ids from the file, made sure to cast those to lower case
* Adjusted some of the test files to use agent names with different casing in the display data dict

