### PR TITLE
Feature/add more UI templates

### DIFF
--- a/ui-templates/README.md
+++ b/ui-templates/README.md
@@ -31,6 +31,7 @@ Each custom data type has:
 * `text`
 * `url`
 * `color`
+* `boolean`
 
 ### Custom types
 

--- a/ui-templates/README.md
+++ b/ui-templates/README.md
@@ -20,7 +20,10 @@ Each custom data type has:
 
 ### Main types
 * `smoldyn_data` - information for populating a `SmoldynData` to visualize a trajectory from Smoldyn
-* (more coming soon)
+* `cytosim_data` - information for populating a `CytosimData` to visualize a trajectory from Cytosim
+* `medyan_data` - information for populating a `MedyanData` to visualize a trajectory from Medyan
+* `springsalad_data` - information for populating a `SpringsaladData` to visualize a trajectory from SpringSaLaD
+* `cellpack_data` - information for populating a `CellpackData` to visualize a trajectory from Cellpack
 
 ### Base types
 
@@ -50,3 +53,4 @@ Each custom data type has:
     * `options` - enum values that a user can choose
 * `time_unit_data`
 * `space_unit_data`
+* `cytosim_object_info`

--- a/ui-templates/base_types.json
+++ b/ui-templates/base_types.json
@@ -33,10 +33,6 @@
         {
             "id": "boolean",
             "data": "boolean"
-        },
-        {
-            "id": "array",
-            "data": "array"
         }
     ]
 }

--- a/ui-templates/base_types.json
+++ b/ui-templates/base_types.json
@@ -29,6 +29,14 @@
         {
             "id": "file",
             "data": "string"
+        },
+        {
+            "id": "boolean",
+            "data": "boolean"
+        },
+        {
+            "id": "array",
+            "data": "array"
         }
     ]
 }

--- a/ui-templates/cellpack_data.json
+++ b/ui-templates/cellpack_data.json
@@ -1,0 +1,101 @@
+{
+    "cellpack_data": {
+        "python::module": "simulariumio.cellpack",
+        "python::object": "CellpackData",
+        "parameters": {
+            "fileContents": {
+                "name": "Result File",
+                "data_type": "file",
+                "description": "A .txt file containing the Cellpack results output",
+                "required": true
+            },
+            "recipeFileContents": {
+                "name": "Recipe File",
+                "data_type": "file",
+                "description": "A file containing the Cellpack recipe that was used to produce the results file. The recipe name must match in both files",
+                "required": true
+            },
+            "geometryType": {
+                "name": "Geometry type",
+                "data_type": "enum",
+                "description": "The display type to use for the ingredients",
+                "help": "If not provided, defaults to DISPLAY_TYPE.PDB",
+                "required": false,
+                "default": "PDB",
+                "python::module": "simulariumio",
+                "python::object": "DISPLAY_TYPE",
+                "options": [
+                    "PDB",
+                    "SPHERE",
+                    "OBJ",
+                    "FIBER",
+                    "SPHERE_GROUP"
+                ]
+            },
+            "metaData": {
+                "name": "Metadata",
+                "data_type": "meta_data",
+                "description": "Provide metadata for this trajectory",
+                "required": false,
+                "help": "If not provided, defaults to box size = [100, 100, 100], scale = 1.0, and no metadata about the trajectory or model"
+            },
+            "displayData": {
+                "name": "Display data",
+                "data_type": "collection",
+                "description": "Provide display information for each particle type from Cellpack",
+                "required": false,
+                "help": "If not provided, defaults to display name from Cellpack, and draws agent as a sphere with radius = 1.0 and default colors",
+                "length": 1,
+                "extendible": true,
+                "key_item": {
+                    "name": "Particle name",
+                    "data_type": "text",
+                    "description": "Provide the name of the particle in Cellpack",
+                    "required": true
+                },
+                "value_item": {
+                    "name": "Particle display data",
+                    "data_type": "display_data",
+                    "description": "Provide information about how to display this particle",
+                    "required": true
+                }
+            },
+            "timeUnits": {
+                "name": "Time units",
+                "data_type": "time_unit_data",
+                "description": "Provide units for time values",
+                "required": false,
+                "help": "If not provided, defaults to 1 second"
+            },
+            "spatialUnits": {
+                "name": "Spatial units",
+                "data_type": "space_unit_data",
+                "description": "Provide units for 3D coordinates",
+                "required": false,
+                "help": "If not provided, defaults to 1 meter"
+            },
+            "handedness": {
+                "name": "Handedness",
+                "data_type": "enum",
+                "description": "The handedness of the data's coordinate system",
+                "help": "If not provided, defaults to RIGHT",
+                "required": false,
+                "python::module": "simulariumio.cellpack",
+                "python::object": "HAND_TYPE",
+                "default": "RIGHT",
+                "options": [
+                    "RIGHT",
+                    "LEFT"
+                ]
+            },
+            "geometryUrl": {
+                "name": "Geometry URL",
+                "data_type": "url",
+                "description": "Base URL for all geometry files",
+                "required": false,
+                "default": "",
+                "help": "If not provided, defaults to none"
+            }
+        }
+    }
+}

--- a/ui-templates/custom-types/cytosim_object_info.json
+++ b/ui-templates/custom-types/cytosim_object_info.json
@@ -1,5 +1,5 @@
 {
-    "display_data": {
+    "cytosim_object_info": {
         "python::module": "simulariumio",
         "python::object": "CytosimObjectInfo",
         "parameters": {

--- a/ui-templates/custom-types/cytosim_object_info.json
+++ b/ui-templates/custom-types/cytosim_object_info.json
@@ -1,0 +1,43 @@
+{
+    "display_data": {
+        "python::module": "simulariumio",
+        "python::object": "CytosimObjectInfo",
+        "parameters": {
+            "fileContents": {
+                "name": "File",
+                "data_type": "file",
+                "description": "A cytosim file",
+                "required": true
+            },
+            "displayData": {
+                "name": "Display data",
+                "data_type": "collection",
+                "description": "Provide display information for each particle type from Cytosim",
+                "required": false,
+                "help": "If not provided, defaults to display name from Cytosim, and draws agent as a sphere with radius = 1.0 and default colors",
+                "length": 1,
+                "extendible": true,
+                "key_item": {
+                    "name": "Particle name",
+                    "data_type": "text",
+                    "description": "Provide the name of the particle in Cytosim",
+                    "required": true
+                },
+                "value_item": {
+                    "name": "Particle display data",
+                    "data_type": "display_data",
+                    "description": "Provide information about how to display this particle",
+                    "required": true
+                }
+            },
+            "position_indices": {
+                "name": "Position Indices",
+                "data_type": "collection",
+                "description": "the columns in Cytosim's reports are not always consistent, use this sto override them if you output has different column indices for position XYZ",
+                "required": false,
+                "default": [2,3,4],
+                "help": "If not provided, defaults to [2, 3, 4]"
+            }
+        }
+    }
+}

--- a/ui-templates/cytosim_data.json
+++ b/ui-templates/cytosim_data.json
@@ -1,0 +1,49 @@
+{
+    "cytosim_data": {
+        "python::module": "simulariumio.cytosim",
+        "python::object": "CytosimData",
+        "parameters": {
+            "metaData": {
+                "name": "Metadata",
+                "data_type": "meta_data",
+                "description": "Provide metadata for this trajectory",
+                "required": false,
+                "help": "If not provided, defaults to box size = [100, 100, 100], scale = 1.0, and no metadata about the trajectory or model"
+            },
+            "cytosimObjectInfo": {
+                "name": "Cytosim object info",
+                "data_type": "collection",
+                "description": "Provide information for reading Cytosim data for a Cytosim object type (fibers, solids, singles, or couples)",
+                "required": true,
+                "length": 1,
+                "extendible": true,
+                "key_item": {
+                    "name": "Cytosim object type",
+                    "data_type": "text",
+                    "description": "Provide the type of the Cytosim object (fibers, solids, singles, or couples)",
+                    "options": [
+                        "fibers",
+                        "solids",
+                        "singles",
+                        "couples"
+                    ],
+                    "required": true
+                },
+                "value_item": {
+                    "name": "Cytosim object info",
+                    "data_type": "cytosim_object_info",
+                    "description": "Provide information about how to read and render the Cytosim data for agents of that object type",
+                    "required": true
+                }
+            },
+            "drawFiberPoints": {
+                "name": "Draw fiber points",
+                "data_type": "boolean",
+                "description": "in addition to drawing a line for each fiber, also draw spheres at every other point along it??",
+                "required": false,
+                "default": false,
+                "help": "Only used for fibers. If not provided, defaults to false"
+            }
+        }
+    }
+}

--- a/ui-templates/medyan_data.json
+++ b/ui-templates/medyan_data.json
@@ -1,0 +1,100 @@
+{
+    "medyan_data": {
+        "python::module": "simulariumio.medyan",
+        "python::object": "MedyanData",
+        "parameters": {
+            "fileContents": {
+                "name": "File",
+                "data_type": "file",
+                "description": "A medyan file",
+                "required": true
+            },
+            "metaData": {
+                "name": "Metadata",
+                "data_type": "meta_data",
+                "description": "Provide metadata for this trajectory",
+                "required": false,
+                "help": "If not provided, defaults to box size = [100, 100, 100], scale = 1.0, and no metadata about the trajectory or model"
+            },
+            "filamentDisplayData": {
+                "name": "Filament display data",
+                "data_type": "collection",
+                "description": "Provide display information for each filament from Medyan",
+                "required": false,
+                "help": "If not provided, defaults to display name of filament[type ID], radius = 1.0 and default colors",
+                "length": 1,
+                "extendible": true,
+                "key_item": {
+                    "name": "Type ID for filament",
+                    "data_type": "text",
+                    "description": "Provide the type ID for the filament",
+                    "required": true
+                },
+                "value_item": {
+                    "name": "Filament display data",
+                    "data_type": "display_data",
+                    "description": "Provide display info to use for rendering this filament",
+                    "required": true
+                }
+            },
+            "linkerDisplayData": {
+                "name": "Linker display data",
+                "data_type": "collection",
+                "description": "Provide display information for each linker from Medyan",
+                "required": false,
+                "help": "If not provided, defaults to display name of linker[type ID], radius = 1.0 and default colors",
+                "length": 1,
+                "extendible": true,
+                "key_item": {
+                    "name": "Type ID for linker",
+                    "data_type": "text",
+                    "description": "Provide the type ID for the linker",
+                    "required": true
+                },
+                "value_item": {
+                    "name": "Linker display data",
+                    "data_type": "display_data",
+                    "description": "Provide display info to use for rendering this linker",
+                    "required": true
+                }
+            },
+            "motorDisplayData": {
+                "name": "Motor display data",
+                "data_type": "collection",
+                "description": "Provide display information for each motor from Medyan",
+                "required": false,
+                "help": "If not provided, defaults to display name of motor[type ID], radius = 1.0 and default colors",
+                "length": 1,
+                "extendible": true,
+                "key_item": {
+                    "name": "Type ID for motor",
+                    "data_type": "text",
+                    "description": "Provide the type ID for the motor",
+                    "required": true
+                },
+                "value_item": {
+                    "name": "Motor display data",
+                    "data_type": "display_data",
+                    "description": "Provide display info to use for rendering this motor",
+                    "required": true
+                }
+            },
+            "agentsWithEndpoints": {
+                "name": "Agents with endpoints",
+                "data_type": "array",
+                "description": "For motors and linkers, a list of output agent names for which to draw spheres at the end points in addition to a line connecting them",
+                "required": false,
+                "extendible": true,
+                "help": "If not provided, no endpoints will be drawn"
+            },
+            "drawFiberPoints": {
+                "name": "Draw fiber points",
+                "data_type": "boolean",
+                "description": "For fibers, in addition to drawing a line for each fiber, also draw spheres at every other point along it?",
+                "required": false,
+                "default": false,
+                "help": "Only for fibers, defaults to false"
+            }
+        }
+    }
+}

--- a/ui-templates/medyan_data.json
+++ b/ui-templates/medyan_data.json
@@ -81,7 +81,7 @@
             },
             "agentsWithEndpoints": {
                 "name": "Agents with endpoints",
-                "data_type": "array",
+                "data_type": "collection",
                 "description": "For motors and linkers, a list of output agent names for which to draw spheres at the end points in addition to a line connecting them",
                 "required": false,
                 "extendible": true,

--- a/ui-templates/springsalad_data.json
+++ b/ui-templates/springsalad_data.json
@@ -1,0 +1,50 @@
+{
+    "springsalad_data": {
+        "python::module": "simulariumio.springsalad",
+        "python::object": "SpringsaladData",
+        "parameters": {
+            "fileContents": {
+                "name": "File",
+                "data_type": "file",
+                "description": "A SpringSaLaD file",
+                "required": true
+            },
+            "metaData": {
+                "name": "Metadata",
+                "data_type": "meta_data",
+                "description": "Provide metadata for this trajectory",
+                "required": false,
+                "help": "If not provided, defaults to box size = [100, 100, 100], scale = 1.0, and no metadata about the trajectory or model"
+            },
+            "displayData": {
+                "name": "Display data",
+                "data_type": "collection",
+                "description": "Provide display information for each particle type from SpringSaLaD, using names from sim view txt file",
+                "required": false,
+                "help": "If not provided, defaults to display name from SpringSaLaD, and draws agent as a sphere with radius = 1.0 and default colors",
+                "length": 1,
+                "extendible": true,
+                "key_item": {
+                    "name": "Particle name",
+                    "data_type": "text",
+                    "description": "Provide the name of the particle in SpringSaLaD",
+                    "required": true
+                },
+                "value_item": {
+                    "name": "Particle display data",
+                    "data_type": "display_data",
+                    "description": "Provide information about how to display this particle",
+                    "required": true
+                }
+            },
+            "drawBonds": {
+                "name": "Draw bonds",
+                "data_type": "boolean",
+                "description": "Draw lines connecting bonded particles?",
+                "required": false,
+                "default": true,
+                "help": "If not provided, defaults to true"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Problem
=======
Add templates for Cellpack, Cytosim, Springsalad, and Medyan
[Link to story or ticket](https://github.com/simularium/simulariumio/issues/74)

Solution
========
Added the new templates, creating a couple new base types and a new custom type along the way.

Tested that it'd work with the example UI by replacing the smoldyn file with these new files. We will need to make some changes to the UI to support these changes, including adding support for booleans and arrays, as well as creating buttons for these new forms, but that's out of scope for this ticket, and we can deal with that after we finish autoconversion for smoldyn.

## Type of change

- New feature (non-breaking change which adds functionality)


