### PR TITLE
Feature/binary reader leaves binary spatial data

### DIFF
--- a/simulariumio/readers/simularium_binary_reader.py
+++ b/simulariumio/readers/simularium_binary_reader.py
@@ -155,7 +155,8 @@ class SimulariumBinaryReader:
             frame_n_values = int(frame_lengths[index] / BINARY_SETTINGS.BYTES_PER_VALUE)
             if binary_spatial_data:
                 data = data_as_bytes[
-                    current_frame_offset + 3 : current_frame_offset + frame_n_values
+                    4 * (current_frame_offset + 3) :
+                    4 * (current_frame_offset + frame_n_values)
                 ]
             else:
                 data = list(

--- a/simulariumio/readers/simularium_binary_reader.py
+++ b/simulariumio/readers/simularium_binary_reader.py
@@ -127,7 +127,7 @@ class SimulariumBinaryReader:
         data_as_bytes: np.ndarray,
         data_as_ints: np.ndarray,
         data_as_floats: np.ndarray,
-        binary_spatial_data: bool,
+        parse_data_as_binary: bool,
     ) -> Dict[str, Any]:
         """
         Parse spatial data binary block from a .simularium binary file
@@ -153,7 +153,7 @@ class SimulariumBinaryReader:
             if index == 0:
                 result["bundleStart"] = frame_index
             frame_n_values = int(frame_lengths[index] / BINARY_SETTINGS.BYTES_PER_VALUE)
-            if binary_spatial_data:
+            if parse_data_as_binary:
                 data = data_as_bytes[
                     4 * (current_frame_offset + 3) :
                     4 * (current_frame_offset + frame_n_values)
@@ -177,7 +177,7 @@ class SimulariumBinaryReader:
 
     @staticmethod
     def load_binary(
-        input_file: InputFileData, binary_spatial_data: bool = False
+        input_file: InputFileData, parse_spatial_data_as_binary: bool = False
     ) -> Dict[str, Any]:
         """
         Load data from the input file in .simularium binary format and update it.
@@ -186,8 +186,8 @@ class SimulariumBinaryReader:
         ----------
         input_file: InputFileData
             A InputFileData object containing binary .simularium data to load
-        binary_spatial_data: bool (optional)
-            Leave spatial data binary encoded in response?
+        parse_spatial_data_as_binary: bool (optional)
+            Leave spatial data binary encoded in returned dict?
             Default = False
         """
         result = {}
@@ -230,7 +230,7 @@ class SimulariumBinaryReader:
                     binary_data.byte_view,
                     binary_data.int_view,
                     binary_data.float_view,
-                    binary_spatial_data,
+                    parse_spatial_data_as_binary,
                 )
             else:
                 raise DataError(

--- a/simulariumio/readers/simularium_binary_reader.py
+++ b/simulariumio/readers/simularium_binary_reader.py
@@ -124,8 +124,10 @@ class SimulariumBinaryReader:
     def _binary_block_spatial_data(
         block_index: int,
         block_info: BinaryBlockInfo,
+        data_as_bytes: np.ndarray,
         data_as_ints: np.ndarray,
         data_as_floats: np.ndarray,
+        binary_spatial_data: bool,
     ) -> Dict[str, Any]:
         """
         Parse spatial data binary block from a .simularium binary file
@@ -151,26 +153,41 @@ class SimulariumBinaryReader:
             if index == 0:
                 result["bundleStart"] = frame_index
             frame_n_values = int(frame_lengths[index] / BINARY_SETTINGS.BYTES_PER_VALUE)
+            if binary_spatial_data:
+                data = data_as_bytes[
+                    current_frame_offset + 3 : current_frame_offset + frame_n_values
+                ]
+            else:
+                data = list(
+                    data_as_floats[
+                        current_frame_offset + 3 : current_frame_offset + frame_n_values
+                    ]
+                )
             result["bundleData"].append(
                 {
                     "frameNumber": frame_index,
                     "time": data_as_floats[current_frame_offset + 1],
-                    "data": list(
-                        data_as_floats[
-                            current_frame_offset
-                            + 3 : current_frame_offset
-                            + frame_n_values
-                        ]
-                    ),
+                    "nAgents": data_as_ints[current_frame_offset + 2],
+                    "data": data,
                 }
             )
             current_frame_offset += frame_n_values
         return result
 
     @staticmethod
-    def load_binary(input_file: InputFileData) -> Dict[str, Any]:
+    def load_binary(
+        input_file: InputFileData, binary_spatial_data: bool = False
+    ) -> Dict[str, Any]:
         """
         Load data from the input file in .simularium binary format and update it.
+
+        Parameters
+        ----------
+        input_file: InputFileData
+            A InputFileData object containing binary .simularium data to load
+        binary_spatial_data: bool (optional)
+            Leave spatial data binary encoded in response?
+            Default = False
         """
         result = {}
         binary_data = SimulariumBinaryReader._binary_data_from_source(input_file)
@@ -209,8 +226,10 @@ class SimulariumBinaryReader:
                 result[block_type] = SimulariumBinaryReader._binary_block_spatial_data(
                     block_index,
                     block_info,
+                    binary_data.byte_view,
                     binary_data.int_view,
                     binary_data.float_view,
+                    binary_spatial_data,
                 )
             else:
                 raise DataError(


### PR DESCRIPTION
Problem
=======
For sending binary frame data back from octopus, it'd be great if the SimulariumBinaryReader had an option to leave the spatial data binary encoded when parsing the binary simularium trajectory.

Goes along with [this ticket](https://github.com/simularium/octopus/issues/5)

Solution
========
Added an option to `SimualriumBinaryReader.load_binary()` to leave the trajectory spatial data binary encoded instead of returning spatial data as a list of floats

## Type of change

- New feature (non-breaking change which adds functionality)

