### PR TITLE
Fix default display data

### DIFF
--- a/simulariumio/data_objects/agent_data.py
+++ b/simulariumio/data_objects/agent_data.py
@@ -647,7 +647,7 @@ class AgentData:
             1: DISPLAY_TYPE.SPHERE,
         }
         for values_per_item in default_display_types:
-            if n_subpoints % float(values_per_item) == 0:
+            if n_subpoints > 0 and n_subpoints % float(values_per_item) == 0:
                 return default_display_types[values_per_item]
         return DISPLAY_TYPE.SPHERE
 

--- a/simulariumio/data_objects/agent_data.py
+++ b/simulariumio/data_objects/agent_data.py
@@ -641,13 +641,15 @@ class AgentData:
         at the given time and agent indices
         """
         n_subpoints = self.n_subpoints[time_index][agent_index]
+        if n_subpoints < 1:
+            return DISPLAY_TYPE.SPHERE
         default_display_types = {
             4: DISPLAY_TYPE.SPHERE_GROUP,
             3: DISPLAY_TYPE.FIBER,
             1: DISPLAY_TYPE.SPHERE,
         }
         for values_per_item in default_display_types:
-            if n_subpoints > 0 and n_subpoints % float(values_per_item) == 0:
+            if n_subpoints % float(values_per_item) == 0:
                 return default_display_types[values_per_item]
         return DISPLAY_TYPE.SPHERE
 

--- a/simulariumio/tests/conftest.py
+++ b/simulariumio/tests/conftest.py
@@ -180,10 +180,6 @@ def three_default_agents() -> TrajectoryData:
                 ]
             ),
             display_data={
-                "C": DisplayData(
-                    name="C",
-                    display_type=DISPLAY_TYPE.SPHERE,
-                ),
                 "W": DisplayData(
                     name="W",
                     display_type=DISPLAY_TYPE.SPHERE,


### PR DESCRIPTION
Problem
=======
Agents that have 0 subpoints get assigned a default `display_type` of `SPHERE_GROUP` rather than `SPHERE`.

Solution
========
Added a check for 0 subpoints in `AgentData._default_display_type_for_agent()`.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

Change summary:
---------------
* only set default `DISPLAY_TYPE` to something other than `SPHERE` if `n_subpoints > 0`
* added a test case where a sphere agent doesn't have display data specified so uses the default