### PR TITLE
Center position data for smoldyn and medyan

### DIFF
--- a/simulariumio/medyan/medyan_converter.py
+++ b/simulariumio/medyan/medyan_converter.py
@@ -276,6 +276,15 @@ class MedyanConverter(TrajectoryConverter):
             self.check_report_progress(line_count / len(lines))
 
         result.n_timesteps = time_index + 1
+        xyz_subpoints = TrajectoryConverter.get_subpoints_xyz(
+            result.subpoints, result.n_subpoints
+        )
+        max_dimensions = TrajectoryConverter.get_xyz_max(xyz_subpoints)
+        min_dimensions = TrajectoryConverter.get_xyz_min(xyz_subpoints)
+        if input_data.center:
+            # center position data
+            translation = -0.5 * (max_dimensions + min_dimensions)
+            result = TrajectoryConverter.translate_positions(result, translation)
 
         return TrajectoryConverter.scale_agent_data(
             result, input_data.meta_data.scale_factor

--- a/simulariumio/medyan/medyan_converter.py
+++ b/simulariumio/medyan/medyan_converter.py
@@ -276,15 +276,11 @@ class MedyanConverter(TrajectoryConverter):
             self.check_report_progress(line_count / len(lines))
 
         result.n_timesteps = time_index + 1
-        xyz_subpoints = TrajectoryConverter.get_subpoints_xyz(
-            result.subpoints, result.n_subpoints
-        )
-        max_dimensions = TrajectoryConverter.get_xyz_max(xyz_subpoints)
-        min_dimensions = TrajectoryConverter.get_xyz_min(xyz_subpoints)
+
         if input_data.center:
-            # center position data
-            translation = -0.5 * (max_dimensions + min_dimensions)
-            result = TrajectoryConverter.translate_positions(result, translation)
+            return TrajectoryConverter.center_and_scale_agent_data(
+                result, input_data.meta_data.scale_factor
+            )
 
         return TrajectoryConverter.scale_agent_data(
             result, input_data.meta_data.scale_factor

--- a/simulariumio/medyan/medyan_data.py
+++ b/simulariumio/medyan/medyan_data.py
@@ -20,6 +20,7 @@ class MedyanData:
     agents_with_endpoints: List[str]
     draw_fiber_points: bool
     plots: List[Dict[str, Any]]
+    center: bool
 
     def __init__(
         self,
@@ -31,6 +32,7 @@ class MedyanData:
         agents_with_endpoints: List[str] = None,
         draw_fiber_points: bool = False,
         plots: List[Dict[str, Any]] = None,
+        center: bool = True,
     ):
         """
         This object holds simulation trajectory outputs
@@ -78,6 +80,10 @@ class MedyanData:
         plots : List[Dict[str, Any]] (optional)
             An object containing plot data already
             in Simularium format
+        center : bool (optional)
+            If true, the spatial values of the data are centered
+            around the origin (0, 0, 0) during conversion
+            Default: True
         """
         self.snapshot_file = snapshot_file
         self.meta_data = meta_data if meta_data is not None else MetaData()
@@ -93,3 +99,4 @@ class MedyanData:
         )
         self.draw_fiber_points = draw_fiber_points
         self.plots = plots if plots is not None else []
+        self.center = center

--- a/simulariumio/smoldyn/smoldyn_converter.py
+++ b/simulariumio/smoldyn/smoldyn_converter.py
@@ -135,6 +135,11 @@ class SmoldynConverter(TrajectoryConverter):
         result.n_agents[time_index] = agent_index
         result.n_timesteps = time_index + 1
 
+        if input_data.center:
+            return TrajectoryConverter.center_and_scale_agent_data(
+                result, input_data.meta_data.scale_factor
+            )
+
         return TrajectoryConverter.scale_agent_data(
             result, input_data.meta_data.scale_factor
         )

--- a/simulariumio/smoldyn/smoldyn_data.py
+++ b/simulariumio/smoldyn/smoldyn_data.py
@@ -28,6 +28,7 @@ class SmoldynData:
     time_units: UnitData
     spatial_units: UnitData
     plots: List[Dict[str, Any]]
+    center: bool
 
     def __init__(
         self,
@@ -37,6 +38,7 @@ class SmoldynData:
         time_units: UnitData = None,
         spatial_units: UnitData = None,
         plots: List[Dict[str, Any]] = None,
+        center: bool = True,
     ):
         """
         This object holds simulation trajectory outputs
@@ -70,6 +72,10 @@ class SmoldynData:
         plots : List[Dict[str, Any]] (optional)
             An object containing plot data already
             in Simularium format
+        center : bool (optional)
+            If true, the spatial values of the data are centered
+            around the origin (0, 0, 0) during conversion
+            Default: True
         """
         self.smoldyn_file = smoldyn_file
         self.meta_data = meta_data if meta_data is not None else MetaData()
@@ -79,6 +85,7 @@ class SmoldynData:
             spatial_units if spatial_units is not None else UnitData("m")
         )
         self.plots = plots if plots is not None else []
+        self.center = center
 
     @classmethod
     def from_dict(

--- a/simulariumio/tests/converters/test_medyan_converter.py
+++ b/simulariumio/tests/converters/test_medyan_converter.py
@@ -301,7 +301,6 @@ data_centered = MedyanData(
 converter_centered = MedyanConverter(data_centered)
 results_centered = JsonWriter.format_trajectory_data(converter_centered._data)
 translation = [-338.15649125, -432.79879825, -189.62899875]
-centered_scale_factor = VIEWER_DIMENSION_RANGE.MAX / (max_range + 1)
 
 
 @pytest.mark.parametrize(
@@ -314,37 +313,37 @@ centered_scale_factor = VIEWER_DIMENSION_RANGE.MAX / (max_range + 1)
                 VIZ_TYPE.FIBER,  # first agent
                 0.0,  # id
                 0.0,  # type
-                translation[0] * centered_scale_factor,  # x
-                translation[1] * centered_scale_factor,  # y
-                translation[2] * centered_scale_factor,  # z
+                0,  # x
+                0,  # y
+                0,  # z
                 0.0,  # x rotation
                 0.0,  # y rotation
                 0.0,  # z rotation
-                actin_radius * centered_scale_factor,  # radius
+                actin_radius * scale_factor_display_data,  # radius
                 6.0,  # number of subpoints
-                (454.3434234 + translation[0]) * centered_scale_factor,
-                (363.439226 + translation[1]) * centered_scale_factor,
-                (265.4405349 + translation[2]) * centered_scale_factor,
-                (519.7377041 + translation[0]) * centered_scale_factor,
-                (351.5737487 + translation[1]) * centered_scale_factor,
-                (180.312405 + translation[2]) * centered_scale_factor,
+                (454.3434234 + translation[0]) * scale_factor_display_data,
+                (363.439226 + translation[1]) * scale_factor_display_data,
+                (265.4405349 + translation[2]) * scale_factor_display_data,
+                (519.7377041 + translation[0]) * scale_factor_display_data,
+                (351.5737487 + translation[1]) * scale_factor_display_data,
+                (180.312405 + translation[2]) * scale_factor_display_data,
                 VIZ_TYPE.FIBER,  # second agent
                 1.0,
                 0.0,
-                translation[0] * centered_scale_factor,
-                translation[1] * centered_scale_factor,
-                translation[2] * centered_scale_factor,
+                0,
+                0,
+                0,
                 0.0,
                 0.0,
                 0.0,
-                actin_radius * centered_scale_factor,
+                actin_radius * scale_factor_display_data,
                 6.0,
-                (547.5943503 + translation[0]) * centered_scale_factor,
-                (280.3075619 + translation[1]) * centered_scale_factor,
-                (307.4127023 + translation[2]) * centered_scale_factor,
-                (535.194707 + translation[0]) * centered_scale_factor,
-                (173.0325428 + translation[1]) * centered_scale_factor,
-                (308.9355694 + translation[2]) * centered_scale_factor,
+                (547.5943503 + translation[0]) * scale_factor_display_data,
+                (280.3075619 + translation[1]) * scale_factor_display_data,
+                (307.4127023 + translation[2]) * scale_factor_display_data,
+                (535.194707 + translation[0]) * scale_factor_display_data,
+                (173.0325428 + translation[1]) * scale_factor_display_data,
+                (308.9355694 + translation[2]) * scale_factor_display_data,
             ],
         )
     ],

--- a/simulariumio/tests/converters/test_medyan_converter.py
+++ b/simulariumio/tests/converters/test_medyan_converter.py
@@ -18,6 +18,7 @@ from simulariumio.exceptions import InputDataError
 
 data = MedyanData(
     snapshot_file=InputFileData(file_path="simulariumio/tests/data/medyan/test.traj"),
+    center=False,
 )
 converter = MedyanConverter(data)
 results = JsonWriter.format_trajectory_data(converter._data)
@@ -124,6 +125,7 @@ data_with_meta_data = MedyanData(
         box_size=np.array([x_size, y_size, z_size]),
     ),
     snapshot_file=InputFileData(file_path="simulariumio/tests/data/medyan/test.traj"),
+    center=False,
 )
 converter_meta_data = MedyanConverter(data_with_meta_data)
 results_meta_data = JsonWriter.format_trajectory_data(converter_meta_data._data)
@@ -172,6 +174,7 @@ data_with_display_data = MedyanData(
             color=linker_color,
         ),
     },
+    center=False,
 )
 converter_display_data = MedyanConverter(data_with_display_data)
 results_display_data = JsonWriter.format_trajectory_data(converter_display_data._data)
@@ -272,6 +275,83 @@ def test_agent_ids():
     assert JsonWriter._check_agent_ids_are_unique_per_frame(results_display_data)
 
 
+data_centered = MedyanData(
+    meta_data=MetaData(
+        box_size=np.array([x_size, y_size, z_size]),
+    ),
+    snapshot_file=InputFileData(file_path="simulariumio/tests/data/medyan/test.traj"),
+    filament_display_data={
+        0: DisplayData(
+            name="Actin",
+            display_type=DISPLAY_TYPE.FIBER,
+            radius=actin_radius,
+            color=actin_color,
+        ),
+    },
+    linker_display_data={
+        1: DisplayData(
+            name="Xlink",
+            display_type=DISPLAY_TYPE.FIBER,
+            radius=linker_radius,
+            color=linker_color,
+        ),
+    },
+    center=True,
+)
+converter_centered = MedyanConverter(data_centered)
+results_centered = JsonWriter.format_trajectory_data(converter_centered._data)
+translation = [-434.78931695, -447.8762742, -205.8179842]
+
+
+@pytest.mark.parametrize(
+    "bundleData, expected_bundleData",
+    [
+        (
+            # just testing the first frame
+            results_centered["spatialData"]["bundleData"][0],
+            [
+                VIZ_TYPE.FIBER,  # first agent
+                0.0,  # id
+                0.0,  # type
+                0.0,  # x
+                0.0,  # y
+                0.0,  # z
+                0.0,  # x rotation
+                0.0,  # y rotation
+                0.0,  # z rotation
+                actin_radius * auto_scale_factor,  # radius
+                6.0,  # number of subpoints
+                (454.3434234 + translation[0]) * auto_scale_factor,
+                (363.439226 + translation[1]) * auto_scale_factor,
+                (265.4405349 + translation[2]) * auto_scale_factor,
+                (519.7377041 + translation[0]) * auto_scale_factor,
+                (351.5737487 + translation[1]) * auto_scale_factor,
+                (180.312405 + translation[2]) * auto_scale_factor,
+                VIZ_TYPE.FIBER,  # second agent
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                actin_radius * auto_scale_factor,
+                6.0,
+                (547.5943503 + translation[0]) * auto_scale_factor,
+                (280.3075619 + translation[1]) * auto_scale_factor,
+                (307.4127023 + translation[2]) * auto_scale_factor,
+                (535.194707 + translation[0]) * auto_scale_factor,
+                (173.0325428 + translation[1]) * auto_scale_factor,
+                (308.9355694 + translation[2]) * auto_scale_factor,
+            ],
+        )
+    ],
+)
+def test_centered_data(bundleData, expected_bundleData):
+    assert False not in np.isclose(expected_bundleData, bundleData["data"])
+
+
 # add in drawing endpoints
 scale_factor = 0.1
 data_with_drawing_endpoints = MedyanData(
@@ -297,6 +377,7 @@ data_with_drawing_endpoints = MedyanData(
         ),
     },
     agents_with_endpoints=["Xlink"],
+    center=False,
 )
 converter_drawing_endpoints = MedyanConverter(data_with_drawing_endpoints)
 results_drawing_endpoints = JsonWriter.format_trajectory_data(

--- a/simulariumio/tests/converters/test_medyan_converter.py
+++ b/simulariumio/tests/converters/test_medyan_converter.py
@@ -300,7 +300,8 @@ data_centered = MedyanData(
 )
 converter_centered = MedyanConverter(data_centered)
 results_centered = JsonWriter.format_trajectory_data(converter_centered._data)
-translation = [-434.78931695, -447.8762742, -205.8179842]
+translation = [-338.15649125, -432.79879825, -189.62899875]
+centered_scale_factor = VIEWER_DIMENSION_RANGE.MAX / (max_range + 1)
 
 
 @pytest.mark.parametrize(
@@ -313,37 +314,37 @@ translation = [-434.78931695, -447.8762742, -205.8179842]
                 VIZ_TYPE.FIBER,  # first agent
                 0.0,  # id
                 0.0,  # type
-                0.0,  # x
-                0.0,  # y
-                0.0,  # z
+                translation[0] * centered_scale_factor,  # x
+                translation[1] * centered_scale_factor,  # y
+                translation[2] * centered_scale_factor,  # z
                 0.0,  # x rotation
                 0.0,  # y rotation
                 0.0,  # z rotation
-                actin_radius * auto_scale_factor,  # radius
+                actin_radius * centered_scale_factor,  # radius
                 6.0,  # number of subpoints
-                (454.3434234 + translation[0]) * auto_scale_factor,
-                (363.439226 + translation[1]) * auto_scale_factor,
-                (265.4405349 + translation[2]) * auto_scale_factor,
-                (519.7377041 + translation[0]) * auto_scale_factor,
-                (351.5737487 + translation[1]) * auto_scale_factor,
-                (180.312405 + translation[2]) * auto_scale_factor,
+                (454.3434234 + translation[0]) * centered_scale_factor,
+                (363.439226 + translation[1]) * centered_scale_factor,
+                (265.4405349 + translation[2]) * centered_scale_factor,
+                (519.7377041 + translation[0]) * centered_scale_factor,
+                (351.5737487 + translation[1]) * centered_scale_factor,
+                (180.312405 + translation[2]) * centered_scale_factor,
                 VIZ_TYPE.FIBER,  # second agent
                 1.0,
                 0.0,
+                translation[0] * centered_scale_factor,
+                translation[1] * centered_scale_factor,
+                translation[2] * centered_scale_factor,
                 0.0,
                 0.0,
                 0.0,
-                0.0,
-                0.0,
-                0.0,
-                actin_radius * auto_scale_factor,
+                actin_radius * centered_scale_factor,
                 6.0,
-                (547.5943503 + translation[0]) * auto_scale_factor,
-                (280.3075619 + translation[1]) * auto_scale_factor,
-                (307.4127023 + translation[2]) * auto_scale_factor,
-                (535.194707 + translation[0]) * auto_scale_factor,
-                (173.0325428 + translation[1]) * auto_scale_factor,
-                (308.9355694 + translation[2]) * auto_scale_factor,
+                (547.5943503 + translation[0]) * centered_scale_factor,
+                (280.3075619 + translation[1]) * centered_scale_factor,
+                (307.4127023 + translation[2]) * centered_scale_factor,
+                (535.194707 + translation[0]) * centered_scale_factor,
+                (173.0325428 + translation[1]) * centered_scale_factor,
+                (308.9355694 + translation[2]) * centered_scale_factor,
             ],
         )
     ],

--- a/simulariumio/tests/converters/test_smoldyn_converter.py
+++ b/simulariumio/tests/converters/test_smoldyn_converter.py
@@ -22,7 +22,8 @@ from simulariumio.exceptions import InputDataError
 data = SmoldynData(
     smoldyn_file=InputFileData(
         file_path="simulariumio/tests/data/smoldyn/example_data.txt"
-    )
+    ),
+    center=False,
 )
 converter = SmoldynConverter(data)
 results = JsonWriter.format_trajectory_data(converter._data)
@@ -265,6 +266,7 @@ data_with_display_data = SmoldynData(
             display_type=DISPLAY_TYPE.SPHERE,
         ),
     },
+    center=False,
 )
 converter_display_data = SmoldynConverter(data_with_display_data)
 results_display_data = JsonWriter.format_trajectory_data(converter_display_data._data)
@@ -384,6 +386,7 @@ data_3D = SmoldynData(
         ),
     },
     spatial_units=UnitData("m"),
+    center=False,
 )
 converter_3D_data = SmoldynConverter(data_3D)
 results_3D_data = JsonWriter.format_trajectory_data(converter_3D_data._data)
@@ -493,6 +496,89 @@ def test_box_size_provided_scaled(box_size, expected_box_size):
 )
 def test_bundleData_3D(bundleData, expected_bundleData):
     assert np.isclose(expected_bundleData, bundleData["data"]).all()
+
+
+# test centering data
+centered_data = SmoldynData(
+    meta_data=MetaData(
+        box_size=np.array([size, size, size]),
+        scale_factor=scale_factor,
+    ),
+    smoldyn_file=InputFileData(
+        file_path="simulariumio/tests/data/smoldyn/example_3D.txt"
+    ),
+    display_data={
+        "green(solution)": DisplayData(
+            name=green_name,
+            display_type=DISPLAY_TYPE.SPHERE,
+            radius=green_radius,
+            color=green_color,
+        ),
+    },
+    spatial_units=UnitData("m"),
+    center=True,
+)
+converter_centered = SmoldynConverter(centered_data)
+results_centered = JsonWriter.format_trajectory_data(converter_centered._data)
+translation = [-52.49355, -43.73305, -23.1069]
+
+
+@pytest.mark.parametrize(
+    "bundleData, expected_bundleData",
+    [
+        (
+            results_centered["spatialData"]["bundleData"][0],
+            [
+                VIZ_TYPE.DEFAULT,  # first agent
+                130.0,  # id
+                0.0,  # type
+                (23.4545 + translation[0]) * scale_factor,  # x
+                (49.2404 + translation[1]) * scale_factor,  # y
+                (12.29 + translation[2]) * scale_factor,  # z
+                0.0,  # x rotation
+                0.0,  # y rotation
+                0.0,  # z rotation
+                green_radius * scale_factor,  # radius
+                0.0,  # subpoints
+                VIZ_TYPE.DEFAULT,  # second agent
+                129.0,
+                0.0,
+                (83.9871 + translation[0]) * scale_factor,
+                (56.5501 + translation[1]) * scale_factor,
+                (33.9238 + translation[2]) * scale_factor,
+                0.0,
+                0.0,
+                0.0,
+                green_radius * scale_factor,
+                0.0,
+                VIZ_TYPE.DEFAULT,  # third agent
+                100.0,
+                1.0,
+                (20 + translation[0]) * scale_factor,
+                (30 + translation[1]) * scale_factor,
+                (20 + translation[2]) * scale_factor,
+                0.0,
+                0.0,
+                0.0,
+                1.0 * scale_factor,
+                0.0,
+                VIZ_TYPE.DEFAULT,  # fourth agent
+                99.0,
+                1.0,
+                (20 + translation[0]) * scale_factor,
+                (30 + translation[1]) * scale_factor,
+                (20 + translation[2]) * scale_factor,
+                0.0,
+                0.0,
+                0.0,
+                1.0 * scale_factor,
+                0.0,
+            ],
+        )
+    ],
+)
+def test_centered_data(bundleData, expected_bundleData):
+    assert bundleData["data"] == expected_bundleData
 
 
 def test_input_file_error():

--- a/simulariumio/trajectory_converter.py
+++ b/simulariumio/trajectory_converter.py
@@ -233,6 +233,7 @@ class TrajectoryConverter:
         min_dimensions: np.array,
         max_dimensions: np.array,
     ) -> float:
+        range = max(max_dimensions - min_dimensions)
         scale_factor = 1
         if np.isclose(range, 0):
             return scale_factor


### PR DESCRIPTION
Problem
=======
It's annoying that for smoldyn and medyan data, centering the data is a separate translation filter step after converting the trajectory to simularium file format. We want to be able to center spatial data as a part of the conversion process instead of requiring an extra step.
[Link to ticket](https://github.com/simularium/simulariumio/issues/145)

This change adds an optional boolean parameter `center` to `SmoldynData` and `MedyanData` which defaults to true, and if true then the spatial data will be translated to be centered around the origin (0, 0, 0) during conversion. If false, the spatial data will not be translated.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires updated or new tests

