### PR TITLE
Append multiple agents to TrajectoryData objects

### DIFF
--- a/simulariumio/data_objects/trajectory_data.py
+++ b/simulariumio/data_objects/trajectory_data.py
@@ -20,10 +20,11 @@ log = logging.getLogger(__name__)
 ###############################################################################
 
 BUFFER_SIZE_INC: DimensionData = DimensionData(
-            total_steps=1,
-            max_agents=1,
-            max_subpoints=1,
-        )
+    total_steps=1,
+    max_agents=1,
+    max_subpoints=1,
+)
+
 
 class TrajectoryData:
     meta_data: MetaData

--- a/simulariumio/tests/converters/test_cellpack_converter.py
+++ b/simulariumio/tests/converters/test_cellpack_converter.py
@@ -3,6 +3,7 @@
 
 import pytest
 from unittest.mock import Mock
+import math
 
 from simulariumio.cellpack import CellpackConverter, HAND_TYPE, CellpackData
 from simulariumio import InputFileData, UnitData, DisplayData, JsonWriter
@@ -153,7 +154,7 @@ def test_box_size(box_size, expected_box_size):
     ],
 )
 def test_bundleData(bundleData, expected_bundleData_data):
-    assert expected_bundleData_data == bundleData["data"]
+    assert math.isclose(expected_bundleData_data, bundleData["data"])
 
 
 @pytest.mark.parametrize(

--- a/simulariumio/tests/converters/test_cellpack_converter.py
+++ b/simulariumio/tests/converters/test_cellpack_converter.py
@@ -3,7 +3,7 @@
 
 import pytest
 from unittest.mock import Mock
-import math
+import numpy as np
 
 from simulariumio.cellpack import CellpackConverter, HAND_TYPE, CellpackData
 from simulariumio import InputFileData, UnitData, DisplayData, JsonWriter
@@ -154,7 +154,7 @@ def test_box_size(box_size, expected_box_size):
     ],
 )
 def test_bundleData(bundleData, expected_bundleData_data):
-    assert math.isclose(expected_bundleData_data, bundleData["data"])
+    assert np.isclose(expected_bundleData_data, bundleData["data"])
 
 
 @pytest.mark.parametrize(

--- a/simulariumio/tests/converters/test_cellpack_converter.py
+++ b/simulariumio/tests/converters/test_cellpack_converter.py
@@ -154,7 +154,7 @@ def test_box_size(box_size, expected_box_size):
     ],
 )
 def test_bundleData(bundleData, expected_bundleData_data):
-    assert np.isclose(expected_bundleData_data, bundleData["data"])
+    assert np.isclose(expected_bundleData_data, bundleData["data"]).all()
 
 
 @pytest.mark.parametrize(

--- a/simulariumio/tests/converters/test_cytosim_converter.py
+++ b/simulariumio/tests/converters/test_cytosim_converter.py
@@ -281,7 +281,7 @@ def test_typeMapping_provided(typeMapping, expected_typeMapping):
     ],
 )
 def test_bundleData(bundleData, expected_bundleData):
-    assert np.isclose(expected_bundleData == bundleData["data"]).all()
+    assert np.isclose(expected_bundleData, bundleData["data"]).all()
 
 
 def test_agent_ids():

--- a/simulariumio/tests/converters/test_cytosim_converter.py
+++ b/simulariumio/tests/converters/test_cytosim_converter.py
@@ -281,7 +281,7 @@ def test_typeMapping_provided(typeMapping, expected_typeMapping):
     ],
 )
 def test_bundleData(bundleData, expected_bundleData):
-    assert expected_bundleData == bundleData["data"]
+    assert np.isclose(expected_bundleData == bundleData["data"]).all()
 
 
 def test_agent_ids():

--- a/simulariumio/tests/converters/test_mcell_converter.py
+++ b/simulariumio/tests/converters/test_mcell_converter.py
@@ -220,7 +220,7 @@ def test_box_size_provided(box_size, expected_box_size):
     ],
 )
 def test_bundleData(bundleData, expected_bundleData):
-    assert expected_bundleData == bundleData["data"]
+    assert np.isclose(expected_bundleData == bundleData["data"]).all()
 
 
 def test_agent_ids():

--- a/simulariumio/tests/converters/test_mcell_converter.py
+++ b/simulariumio/tests/converters/test_mcell_converter.py
@@ -220,7 +220,7 @@ def test_box_size_provided(box_size, expected_box_size):
     ],
 )
 def test_bundleData(bundleData, expected_bundleData):
-    assert np.isclose(expected_bundleData == bundleData["data"]).all()
+    assert np.isclose(expected_bundleData, bundleData["data"]).all()
 
 
 def test_agent_ids():

--- a/simulariumio/tests/converters/test_md_converter.py
+++ b/simulariumio/tests/converters/test_md_converter.py
@@ -362,7 +362,7 @@ third_frame_data = [
     ],
 )
 def test_bundleData(bundleData, expected_bundleData):
-    assert expected_bundleData == bundleData["data"]
+    assert np.isclose(expected_bundleData == bundleData["data"]).all()
 
 
 def test_agent_ids():

--- a/simulariumio/tests/converters/test_md_converter.py
+++ b/simulariumio/tests/converters/test_md_converter.py
@@ -362,7 +362,7 @@ third_frame_data = [
     ],
 )
 def test_bundleData(bundleData, expected_bundleData):
-    assert np.isclose(expected_bundleData == bundleData["data"]).all()
+    assert np.isclose(expected_bundleData, bundleData["data"]).all()
 
 
 def test_agent_ids():

--- a/simulariumio/tests/converters/test_medyan_converter.py
+++ b/simulariumio/tests/converters/test_medyan_converter.py
@@ -254,7 +254,7 @@ def test_typeMapping_with_display_data(typeMapping, expected_typeMapping):
     ],
 )
 def test_bundleData(bundleData, expected_bundleData):
-    assert np.isclose(expected_bundleData == bundleData["data"]).all()
+    assert np.isclose(expected_bundleData, bundleData["data"]).all()
 
 
 def test_agent_ids():
@@ -477,7 +477,7 @@ def test_typeMapping_with_drawing_endpoints(typeMapping, expected_typeMapping):
     ],
 )
 def test_bundleData_drawing_endpoints(bundleData, expected_bundleData):
-    assert np.isclose(expected_bundleData == bundleData["data"]).all()
+    assert np.isclose(expected_bundleData, bundleData["data"]).all()
 
 
 def test_agent_ids_drawing_endpoints():

--- a/simulariumio/tests/converters/test_medyan_converter.py
+++ b/simulariumio/tests/converters/test_medyan_converter.py
@@ -254,7 +254,7 @@ def test_typeMapping_with_display_data(typeMapping, expected_typeMapping):
     ],
 )
 def test_bundleData(bundleData, expected_bundleData):
-    assert expected_bundleData == bundleData["data"]
+    assert np.isclose(expected_bundleData == bundleData["data"]).all()
 
 
 def test_agent_ids():
@@ -477,7 +477,7 @@ def test_typeMapping_with_drawing_endpoints(typeMapping, expected_typeMapping):
     ],
 )
 def test_bundleData_drawing_endpoints(bundleData, expected_bundleData):
-    assert expected_bundleData == bundleData["data"]
+    assert np.isclose(expected_bundleData == bundleData["data"]).all()
 
 
 def test_agent_ids_drawing_endpoints():

--- a/simulariumio/tests/converters/test_readdy_converter.py
+++ b/simulariumio/tests/converters/test_readdy_converter.py
@@ -359,7 +359,7 @@ results_ignore_types = JsonWriter.format_trajectory_data(converter_ignore_type._
     ],
 )
 def test_bundleData(bundleData, expected_bundleData):
-    assert np.isclose(expected_bundleData == bundleData["data"]).all()
+    assert np.isclose(expected_bundleData, bundleData["data"]).all()
 
 
 def test_agent_ids():
@@ -421,7 +421,7 @@ def test_typeMapping_ignore_types(typeMapping, expected_typeMapping):
     ],
 )
 def test_bundleData_ignored_types(bundleData, expected_bundleData):
-    assert np.isclose(expected_bundleData == bundleData["data"]).all()
+    assert np.isclose(expected_bundleData, bundleData["data"]).all()
 
 
 def test_agent_ids_ignored_types():

--- a/simulariumio/tests/converters/test_readdy_converter.py
+++ b/simulariumio/tests/converters/test_readdy_converter.py
@@ -359,7 +359,7 @@ results_ignore_types = JsonWriter.format_trajectory_data(converter_ignore_type._
     ],
 )
 def test_bundleData(bundleData, expected_bundleData):
-    assert expected_bundleData == bundleData["data"]
+    assert np.isclose(expected_bundleData == bundleData["data"]).all()
 
 
 def test_agent_ids():
@@ -421,7 +421,7 @@ def test_typeMapping_ignore_types(typeMapping, expected_typeMapping):
     ],
 )
 def test_bundleData_ignored_types(bundleData, expected_bundleData):
-    assert expected_bundleData == bundleData["data"]
+    assert np.isclose(expected_bundleData == bundleData["data"]).all()
 
 
 def test_agent_ids_ignored_types():

--- a/simulariumio/tests/converters/test_smoldyn_converter.py
+++ b/simulariumio/tests/converters/test_smoldyn_converter.py
@@ -345,7 +345,7 @@ def test_typeMapping_with_display_data(typeMapping, expected_typeMapping):
     ],
 )
 def test_bundleData(bundleData, expected_bundleData):
-    assert expected_bundleData == bundleData["data"]
+    assert np.isclose(expected_bundleData == bundleData["data"]).all()
 
 
 def test_agent_ids():
@@ -462,7 +462,7 @@ def test_typeMapping_with_3D_data(typeMapping, expected_typeMapping):
     ],
 )
 def test_bundleData_3D(bundleData, expected_bundleData):
-    assert expected_bundleData == bundleData["data"]
+    assert np.isclose(expected_bundleData == bundleData["data"]).all()
 
 
 def test_input_file_error():

--- a/simulariumio/tests/converters/test_smoldyn_converter.py
+++ b/simulariumio/tests/converters/test_smoldyn_converter.py
@@ -345,7 +345,7 @@ def test_typeMapping_with_display_data(typeMapping, expected_typeMapping):
     ],
 )
 def test_bundleData(bundleData, expected_bundleData):
-    assert np.isclose(expected_bundleData == bundleData["data"]).all()
+    assert np.isclose(expected_bundleData, bundleData["data"]).all()
 
 
 def test_agent_ids():
@@ -462,7 +462,7 @@ def test_typeMapping_with_3D_data(typeMapping, expected_typeMapping):
     ],
 )
 def test_bundleData_3D(bundleData, expected_bundleData):
-    assert np.isclose(expected_bundleData == bundleData["data"]).all()
+    assert np.isclose(expected_bundleData, bundleData["data"]).all()
 
 
 def test_input_file_error():

--- a/simulariumio/tests/converters/test_springsalad_converter.py
+++ b/simulariumio/tests/converters/test_springsalad_converter.py
@@ -268,7 +268,7 @@ def test_typeMapping_provided(typeMapping, expected_typeMapping):
     ],
 )
 def test_bundleData(bundleData, expected_bundleData):
-    assert expected_bundleData == bundleData["data"]
+    assert np.isclose(expected_bundleData == bundleData["data"]).all()
 
 
 def test_agent_ids():
@@ -416,7 +416,7 @@ def test_typeMapping_bonds(typeMapping, expected_typeMapping):
     ],
 )
 def test_bundleData_bonds(bundleData, expected_bundleData):
-    assert expected_bundleData == bundleData["data"]
+    assert np.isclose(expected_bundleData == bundleData["data"]).all()
 
 
 def test_agent_ids_bonds():

--- a/simulariumio/tests/converters/test_springsalad_converter.py
+++ b/simulariumio/tests/converters/test_springsalad_converter.py
@@ -268,7 +268,7 @@ def test_typeMapping_provided(typeMapping, expected_typeMapping):
     ],
 )
 def test_bundleData(bundleData, expected_bundleData):
-    assert np.isclose(expected_bundleData == bundleData["data"]).all()
+    assert np.isclose(expected_bundleData, bundleData["data"]).all()
 
 
 def test_agent_ids():
@@ -416,7 +416,7 @@ def test_typeMapping_bonds(typeMapping, expected_typeMapping):
     ],
 )
 def test_bundleData_bonds(bundleData, expected_bundleData):
-    assert np.isclose(expected_bundleData == bundleData["data"]).all()
+    assert np.isclose(expected_bundleData, bundleData["data"]).all()
 
 
 def test_agent_ids_bonds():


### PR DESCRIPTION
Problem
=======
Refer to #153 

Solution
========
* updated buffer size for single agents
* enforce integer datatypes for indices

## Type of change
- Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
Refer to this [notebook](https://github.com/simularium/subcell-analysis/blob/simularium_multiple_repeats/notebooks/create_simularium_outputs.ipynb) which creates a single simularium file from multiple cytosim simulations

Screenshots:
-----------------------
Simularium trajectory with multiple actin filaments visualized simultaneously
![image](https://github.com/simularium/simulariumio/assets/101426188/99de652d-af67-4f89-85aa-2b95a6eb78ce)


Keyfiles:
-----------------------
`simulariumio/data_objects/trajectory_data.py`

