### PR TITLE
Pin cellpack version to 1.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ md = [
   "MDAnalysisTests>=2.0.0",
 ]
 cellpack = [
-  "cellpack>=1.0.3",
+  "cellpack==1.0.3",
 ]
 tutorial = [
   "jupyter",


### PR DESCRIPTION
Time estimate or Size
=======
xsmall

Problem
=======
cellPACK tests were failing on dependabot PRs 

Solution
========
Pinned the cellPACK version to 1.0.3. Will need to revisit whether this version needs to be updated in the future

## Type of change
- Bug fix (non-breaking change which fixes an issue)

Change summary:
---------------
* Pin cellPACK version to 1.0.3

Steps to Verify:
----------------
`just test` passes without errors


Keyfiles (delete if not relevant):
-----------------------
1. pyproject.toml
