### PR TITLE
Fix/use display names

### DIFF
--- a/simulariumio/data_objects/agent_data.py
+++ b/simulariumio/data_objects/agent_data.py
@@ -214,14 +214,14 @@ class AgentData:
                     tid = last_tid
                     last_tid += 1
                     type_id_mapping[type_name] = tid
-                    type_name_mapping[str(tid)] = {"name": type_name}
                     if type_name not in self.display_data:
                         raise DataError(
                             f"Please provide DisplayData for agent type {type_name}"
                         )
-                    type_name_mapping[str(tid)]["geometry"] = dict(
-                        self.display_data[type_name]
-                    )
+                    type_name_mapping[str(tid)] = {
+                        "name": self.display_data[type_name].name,
+                        "geometry" : dict(self.display_data[type_name])
+                    }
                 type_ids[time_index][agent_index] = type_id_mapping[type_name]
         return type_ids, type_name_mapping
 

--- a/simulariumio/physicell/physicell_converter.py
+++ b/simulariumio/physicell/physicell_converter.py
@@ -223,7 +223,7 @@ class PhysicellConverter(TrajectoryConverter):
                     last_id=last_id,
                     type_mapping=type_mapping,
                 )
-                if type_mapping[tid] not in input_data.display_data:
+                if type_mapping[tid] not in result.display_data:
                     result.display_data[type_mapping[tid]] = DisplayData(
                         name=type_mapping[tid],
                         display_type=DISPLAY_TYPE.SPHERE,
@@ -376,6 +376,7 @@ class PhysicellConverter(TrajectoryConverter):
                             phase_id
                         )
                     agent_data.display_data[type_name] = display_data
+                    agent_data.display_data[type_name].name = type_name
         input_data.meta_data.scale_factor = scale_factor
         input_data.meta_data._set_box_size()
         return TrajectoryData(

--- a/simulariumio/tests/converters/test_trajectory_converter.py
+++ b/simulariumio/tests/converters/test_trajectory_converter.py
@@ -274,6 +274,15 @@ def test_camera_defaults(camera, expected_camera):
 
 
 # test type mapping
+test_display_name = "Test display name"
+default_agents_converter._data.agent_data.display_data["C"].name = test_display_name
+default_agents_data_display_name = JsonWriter.format_trajectory_data(
+    default_agents_converter._data
+)
+display_name_type_mapping = minimal_custom_type_mappings()
+display_name_type_mapping["0"]["name"] = test_display_name
+
+
 @pytest.mark.parametrize(
     "typeMapping, expected_typeMapping",
     [
@@ -305,6 +314,10 @@ def test_camera_defaults(camera, expected_camera):
                     },
                 },
             },
+        ),
+        (
+            default_agents_data_display_name["trajectoryInfo"]["typeMapping"],
+            display_name_type_mapping,
         ),
     ],
 )


### PR DESCRIPTION
Time estimate or Size
=======
small, 5 min

Problem
=======
Agent names provided in `DisplayData` were not being saved out as the agent name in the type mapping, and so the raw type name in the spatial data was being displayed in the left panel of the viewer. 

Display names are useful to, for example, display the same name for agents that have different geometry (which we need to do for ipub).

Solution
========
Fixed `AgentData.get_type_ids_and_mapping()` so that it uses the name in the display data, this method is called whenever a .simularium file is saved out.

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- This change requires updated or new tests

Change summary:
---------------
* use display name when creating type mapping in `AgentData`
* fix another bug with display names that was revealed in `PhysicellConverter` after fixing
* add a test that fails without the `AgentData` fix
