### PR TITLE
Make centering cytosim fibers optional

### DIFF
--- a/simulariumio/cytosim/cytosim_converter.py
+++ b/simulariumio/cytosim/cytosim_converter.py
@@ -192,6 +192,7 @@ class CytosimConverter(TrajectoryConverter):
         overall_line: int,
         total_lines: int,
         scale_factor: float = None,
+        center_fibers: bool = False,
     ) -> Tuple[Dict[str, Any], List[int], int]:
         """
         Parse a Cytosim output file containing objects
@@ -277,7 +278,8 @@ class CytosimConverter(TrajectoryConverter):
         result, scale_factor = TrajectoryConverter.scale_agent_data(
             result, scale_factor
         )
-        result = TrajectoryConverter.center_fiber_positions(result)
+        if center_fibers:
+            result = TrajectoryConverter.center_fiber_positions(result)
         result.n_timesteps = time_index + 1
         return (result, used_unique_IDs, overall_line, scale_factor)
 
@@ -319,6 +321,7 @@ class CytosimConverter(TrajectoryConverter):
                     overall_line,
                     total_lines,
                     input_data.meta_data.scale_factor,
+                    input_data.center_fibers,
                 )
             except Exception as e:
                 raise InputDataError(f"Error reading input cytosim data: {e}")

--- a/simulariumio/cytosim/cytosim_data.py
+++ b/simulariumio/cytosim/cytosim_data.py
@@ -19,6 +19,7 @@ class CytosimData:
     meta_data: MetaData
     draw_fiber_points: bool
     plots: List[Dict[str, Any]]
+    center_fibers: bool
 
     def __init__(
         self,
@@ -26,6 +27,7 @@ class CytosimData:
         meta_data: MetaData = None,
         draw_fiber_points: bool = False,
         plots: List[Dict[str, Any]] = None,
+        center_fibers: bool = False,
     ):
         """
         This object holds simulation trajectory outputs
@@ -50,8 +52,12 @@ class CytosimData:
         plots : List[Dict[str, Any]] (optional)
             An object containing plot data already
             in Simularium format
+        center_fibers : bool
+            Set the position of each fiber as the center of its points?
+            Otherwise set it to zero.
         """
         self.object_info = object_info
         self.meta_data = meta_data if meta_data is not None else MetaData()
         self.draw_fiber_points = draw_fiber_points
         self.plots = plots if plots is not None else []
+        self.center_fibers = center_fibers


### PR DESCRIPTION
Time estimate or Size
=======
xsmall

Problem
=======
While visualizing some Cytosim models for subcell research project, we need to rotate the fiber to align it, and if it is centered first the position gets offset incorrectly. 

Solution
========
Made centering optional to allow the user to control it. 

I set it to default to no centering because the viewer does centering now.

## Type of change

- New feature (non-breaking change which adds functionality)
