### PR TITLE
use python 3.10 instead of 3.8 for main build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.9, "3.10"]
         os: [ubuntu-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Rendering capabilities planned for future:
 ## Installation
 **Install Requires:** 
 
-* Requires Python 3.7, 3.8, or 3.9
+* Requires Python 3.9 or 3.10
 
 * If ReaDDy trajectories will be converted, the ReaDDy python package must be installed:
 (add conda forge channel if it's not already: `conda config --add channels conda-forge`)

--- a/environment.yml
+++ b/environment.yml
@@ -2,5 +2,5 @@ name: anaconda-client-env
 channels:
   - conda-forge
 dependencies:
-  - readdy==2.0.9
+  - readdy
   - numpy>=1.20


### PR DESCRIPTION
Time estimate or Size
=======
xsmall

Problem
=======
The build was broken for Python 3.8, because a dependency of the `MDAnalysis` (which is needed for the MD converter) no longer supports Python 3.8. 

[Link to story or ticket](https://github.com/simularium/simulariumio/issues/189)

Solution
========
Since Python 3.8 (see [here](https://devguide.python.org/versions/)) is reaching end of life in October anyways, it feels more appropriate to move our tests to newer versions of Python rather than pin dependencies to make sure we don't install the newest versions of packages that are no longer supporting Python 3.8.


## Changes
- updated tests to use Python 3.9 and 3.10 instead of 3.8 and 3.9
- Removed pinned version of Readdy, since that older version is not compatible with Python 3.10, and all of the tests still pass with a newer version of Readdy installed, so I imagine the original reason for pinning it to a specific version is resolved
