### PR TITLE
add new issue template for new simulariumio converter requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/converter_request.md
+++ b/.github/ISSUE_TEMPLATE/converter_request.md
@@ -1,0 +1,16 @@
+---
+name: New Converter Request
+about: '"I would like to visualize x in Simularium"'
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Simulation Engine Details
+
+_Please provide information about the simulation you would like to visualize in Simularium._
+
+## Documentation and Example Data
+
+_Please provide any links to documentation about the simulation engine and any helpful example data_


### PR DESCRIPTION
Time estimate or Size
=======
xsmall

Problem
=======
A couple weeks ago, Jess Yu requested a new Github issue type in simulariumio for requesting new simulariumio converters. This could be useful at conferences or anywhere else that simularium is being advertised, as a clear place to go when someone is interested in using simularium to visualize their simulation. 

Solution
========
Added a new issue type, following a similar pattern to what we have currently for new feature requests.
