### PR TITLE
Update print statements to use logging in `json_writer.py`

### DIFF
--- a/simulariumio/cellpack/cellpack_converter.py
+++ b/simulariumio/cellpack/cellpack_converter.py
@@ -362,7 +362,7 @@ class CellpackConverter(TrajectoryConverter):
         """
         Return a TrajectoryData object containing the Cellpack data
         """
-        print("Reading Cellpack Data -------------")
+        log.info("Reading Cellpack Data -------------")
         # currently only converts one model, ie one time step
         time_step_index = 0
         # default scale for cellpack => simularium

--- a/simulariumio/plot_readers/histogram_plot_reader.py
+++ b/simulariumio/plot_readers/histogram_plot_reader.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
-from typing import Dict, Any
+from typing import Any, Dict
 
 from .plot_reader import PlotReader
 
@@ -18,7 +18,7 @@ class HistogramPlotReader(PlotReader):
         """
         Return an object containing the data shaped for Simularium format
         """
-        print("Reading Histogram Data -------------")
+        log.info("Reading Histogram Data -------------")
         simularium_data = {}
         # layout info
         simularium_data["layout"] = {

--- a/simulariumio/writers/json_writer.py
+++ b/simulariumio/writers/json_writer.py
@@ -124,7 +124,7 @@ class JsonWriter(Writer):
         trajectory_data: TrajectoryData
             the data to format
         """
-        print("Converting Trajectory Data to JSON -------------")
+        log.info("Converting Trajectory Data to JSON -------------")
         trajectory_data.agent_data._check_subpoints_match_display_type()
         simularium_data = {}
         # trajectory info
@@ -181,10 +181,10 @@ class JsonWriter(Writer):
         if validate_ids:
             Writer._validate_ids(trajectory_data)
         json_data = JsonWriter.format_trajectory_data(trajectory_data)
-        print("Writing JSON -------------")
+        log.info("Writing JSON -------------")
         with open(f"{output_path}.simularium", "w+") as outfile:
             json.dump(json_data, outfile)
-        print(f"saved to {output_path}.simularium")
+        log.info(f"saved to {output_path}.simularium")
 
     @staticmethod
     def save_plot_data(plot_data: List[Dict[str, Any]], output_path: str):


### PR DESCRIPTION
Time estimate or Size
=======
xsmall

Problem
=======
cellPACK uses simulariumio to convert outputs. The output stream gets a lot of noisy outputs during the conversion process. Changing the print statements to logging will allow users to configure the output level as needed.

Solution
========
Changes print statements to use python logging in `json_writer.py`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

Change summary:
---------------
* print-> log.info
